### PR TITLE
Add max_taker_vol RPC method

### DIFF
--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/rpc_methods.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/rpc_methods.dart
@@ -42,6 +42,7 @@ export 'swaps/legacy/order_status.dart';
 export 'swaps/legacy/sell.dart';
 export 'swaps/legacy/set_price.dart';
 export 'swaps/max_maker_vol.dart';
+export 'swaps/max_taker_vol.dart';
 export 'swaps/my_recent_swaps.dart';
 export 'swaps/orderbook.dart';
 export 'swaps/orderbook_depth.dart';

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swaps/max_taker_vol.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swaps/max_taker_vol.dart
@@ -1,0 +1,63 @@
+import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart';
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+/// Request to get the maximum taker volume available for a coin.
+///
+/// This value can be used directly when placing a `sell` order or divided by
+/// the trade price for a `buy` order. It accounts for DEX fees and blockchain
+/// miner fees so that the returned volume is immediately usable.
+class MaxTakerVolRequest
+    extends BaseRequest<MaxTakerVolResponse, GeneralErrorResponse> {
+  MaxTakerVolRequest({
+    required String rpcPass,
+    required this.coin,
+    this.tradeWith,
+  }) : super(method: 'max_taker_vol', rpcPass: rpcPass, mmrpc: null);
+
+  /// The ticker of the coin you want to query
+  final String coin;
+
+  /// The coin to trade with. Defaults to [coin] if not provided
+  final String? tradeWith;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return super.toJson().deepMerge({
+      'params': {'coin': coin, if (tradeWith != null) 'trade_with': tradeWith},
+    });
+  }
+
+  @override
+  MaxTakerVolResponse parse(Map<String, dynamic> json) =>
+      MaxTakerVolResponse.parse(json);
+}
+
+class MaxTakerVolResponse extends BaseResponse {
+  MaxTakerVolResponse({
+    required super.mmrpc,
+    required this.result,
+    this.coin,
+    super.id,
+  });
+
+  factory MaxTakerVolResponse.parse(Map<String, dynamic> json) {
+    return MaxTakerVolResponse(
+      mmrpc: json.valueOrNull<String>('mmrpc'),
+      id: json.valueOrNull<String>('id'),
+      coin: json.valueOrNull<String>('coin'),
+      result: FractionalValue.fromJson(json.value<JsonMap>('result')),
+    );
+  }
+
+  /// The coin queried, if provided by the API
+  final String? coin;
+
+  /// The maximum taker volume available represented as a [FractionalValue]
+  final FractionalValue result;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {'result': result.toJson(), if (coin != null) 'coin': coin};
+  }
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swaps/swap_methods_namespace.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swaps/swap_methods_namespace.dart
@@ -79,6 +79,21 @@ class SwapMethodsNamespace extends BaseRpcMethodNamespace {
     );
   }
 
+  /// Returns the maximum taker volume available for the selected coin
+  Future<MaxTakerVolResponse> maxTakerVol({
+    required String coin,
+    String? tradeWith,
+    String? rpcPass,
+  }) {
+    return execute(
+      MaxTakerVolRequest(
+        rpcPass: rpcPass ?? this.rpcPass ?? '',
+        coin: coin,
+        tradeWith: tradeWith,
+      ),
+    );
+  }
+
   /// Returns the data of the most recent atomic swaps executed by the
   /// Komodo DeFi Framework API node
   ///


### PR DESCRIPTION
## Summary
- implement `max_taker_vol` request/response
- export and wire into swap namespace
- mark `max_taker_vol` as legacy RPC method
- document how to use the returned value

## Testing
- `dart format packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swaps/max_taker_vol.dart`
- `flutter analyze packages/komodo_defi_rpc_methods` *(fails: 3213 issues found)*
- `flutter build web` *(fails first run)*
- `flutter build web`

------
https://chatgpt.com/codex/tasks/task_e_686e18c235fc8331bb6192ae54e7ca18