### PR TITLE
feat: add staking support flag to Asset

### DIFF
--- a/packages/komodo_defi_sdk/example/lib/screens/asset_page.dart
+++ b/packages/komodo_defi_sdk/example/lib/screens/asset_page.dart
@@ -336,6 +336,7 @@ class _AssetHeaderState extends State<AssetHeader> {
     final hasAddresses =
         widget.pubkeys != null && widget.pubkeys!.keys.isNotEmpty;
     final supportsSigning = widget.asset.supportsMessageSigning;
+    final supportsStaking = widget.asset.supportsStaking;
 
     return Wrap(
       alignment: WrapAlignment.spaceEvenly,
@@ -365,18 +366,19 @@ class _AssetHeaderState extends State<AssetHeader> {
           icon: const Icon(Icons.qr_code),
           label: const Text('Receive'),
         ),
-        FilledButton.tonalIcon(
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute<void>(
-                builder: (context) => StakingScreen(asset: widget.asset),
-              ),
-            );
-          },
-          icon: const Icon(Icons.stacked_line_chart),
-          label: const Text('Stake'),
-        ),
+        if (supportsStaking)
+          FilledButton.tonalIcon(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute<void>(
+                  builder: (context) => StakingScreen(asset: widget.asset),
+                ),
+              );
+            },
+            icon: const Icon(Icons.stacked_line_chart),
+            label: const Text('Stake'),
+          ),
 
         Tooltip(
           message:

--- a/packages/komodo_defi_types/lib/src/assets/asset.dart
+++ b/packages/komodo_defi_types/lib/src/assets/asset.dart
@@ -70,6 +70,18 @@ class Asset extends Equatable {
   /// coin config.
   bool get supportsMessageSigning => signMessagePrefix != null;
 
+  /// Whether this asset supports staking operations.
+  ///
+  /// The KDF API currently supports staking for Qtum (QRC20) and
+  /// Cosmos/Tendermint based coins.
+  bool get supportsStaking => switch (protocol.subClass) {
+        CoinSubClass.qrc20 ||
+        CoinSubClass.tendermint ||
+        CoinSubClass.tendermintToken =>
+          true,
+        _ => false,
+      };
+
   JsonMap toJson() => {
         'protocol': protocol.toJson(),
         'id': id.toJson(),


### PR DESCRIPTION
## Summary
- expose `supportsStaking` on `Asset`
- show staking button in example only when supported

## Testing
- `flutter analyze` *(fails: many existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_6879280f0368832680563aa9576b87f8