### PR TITLE
fix framework bootstrap for node env

### DIFF
--- a/packages/komodo_defi_framework/web/res/kdflib_bootstrapper.js
+++ b/packages/komodo_defi_framework/web/res/kdflib_bootstrapper.js
@@ -73,7 +73,12 @@ Object.assign(kdf, kdflib);
 kdf.init_wasm().catch(console.error);
 
 // @ts-ignore
-window.kdf = kdf;
+if (typeof window !== "undefined") {
+    window.kdf = kdf;
+} else if (typeof globalThis !== "undefined") {
+    // Fallback for non-browser environments
+    globalThis.kdf = kdf;
+}
 
 export default kdf;
 export { kdf };

--- a/packages/komodo_defi_sdk/example/web/kdf/res/kdflib_bootstrapper.js
+++ b/packages/komodo_defi_sdk/example/web/kdf/res/kdflib_bootstrapper.js
@@ -73,7 +73,12 @@ Object.assign(kdf, kdflib);
 kdf.init_wasm().catch(console.error);
 
 // @ts-ignore
-window.kdf = kdf;
+if (typeof window !== "undefined") {
+    window.kdf = kdf;
+} else if (typeof globalThis !== "undefined") {
+    // Fallback for non-browser environments
+    globalThis.kdf = kdf;
+}
 
 export default kdf;
 export { kdf };


### PR DESCRIPTION
## Summary
- handle environments where `window` is undefined in the JS bootstrapper

## Testing
- `flutter analyze`
- `flutter test test_fix.dart` *(fails: cannot run without flutter_test/test)*

------
https://chatgpt.com/codex/tasks/task_e_687a41b5730083269e3795d4e7e7b182