### PR TITLE
feat(activation): disable tx history when using external strategy

### DIFF
--- a/packages/komodo_defi_sdk/lib/src/activation/protocol_strategies/eth_task_activation_strategy.dart
+++ b/packages/komodo_defi_sdk/lib/src/activation/protocol_strategies/eth_task_activation_strategy.dart
@@ -78,7 +78,8 @@ class EthTaskActivationStrategy extends ProtocolActivationStrategy {
           erc20Tokens:
               children?.map((e) => TokensRequest(ticker: e.id.id)).toList() ??
               [],
-          txHistory: _shouldEnableTxHistory(asset),
+          txHistory: const EtherscanProtocolHelper()
+              .shouldEnableTransactionHistory(asset),
           privKeyPolicy: privKeyPolicy,
         ),
       );
@@ -215,6 +216,3 @@ class EthTaskActivationStrategy extends ProtocolActivationStrategy {
     }
   }
 }
-
-bool _shouldEnableTxHistory(Asset asset) =>
-    !const EtherscanProtocolHelper().supportsProtocol(asset);

--- a/packages/komodo_defi_sdk/lib/src/activation/protocol_strategies/eth_with_tokens_activation_strategy.dart
+++ b/packages/komodo_defi_sdk/lib/src/activation/protocol_strategies/eth_with_tokens_activation_strategy.dart
@@ -97,7 +97,8 @@ class EthWithTokensActivationStrategy extends ProtocolActivationStrategy {
           erc20Tokens:
               children?.map((e) => TokensRequest(ticker: e.id.id)).toList() ??
               [],
-          txHistory: _shouldEnableTxHistory(asset),
+          txHistory: const EtherscanProtocolHelper()
+              .shouldEnableTransactionHistory(asset),
           privKeyPolicy: privKeyPolicy,
         ),
       );
@@ -139,6 +140,3 @@ class EthWithTokensActivationStrategy extends ProtocolActivationStrategy {
     }
   }
 }
-
-bool _shouldEnableTxHistory(Asset asset) =>
-    !const EtherscanProtocolHelper().supportsProtocol(asset);

--- a/packages/komodo_defi_sdk/lib/src/activation/protocol_strategies/tendermint_activation_strategy.dart
+++ b/packages/komodo_defi_sdk/lib/src/activation/protocol_strategies/tendermint_activation_strategy.dart
@@ -75,7 +75,8 @@ class TendermintActivationStrategy extends ProtocolActivationStrategy {
                     .toList() ??
                 [],
             getBalances: true,
-            txHistory: _shouldEnableTxHistory(asset),
+            txHistory: const EtherscanProtocolHelper()
+                .shouldEnableTransactionHistory(asset),
             privKeyPolicy: privKeyPolicy,
           ),
         );
@@ -123,6 +124,3 @@ class TendermintActivationStrategy extends ProtocolActivationStrategy {
     }
   }
 }
-
-bool _shouldEnableTxHistory(Asset asset) =>
-    !const EtherscanProtocolHelper().supportsProtocol(asset);

--- a/packages/komodo_defi_sdk/lib/src/transaction_history/strategies/etherscan_transaction_history_strategy.dart
+++ b/packages/komodo_defi_sdk/lib/src/transaction_history/strategies/etherscan_transaction_history_strategy.dart
@@ -13,8 +13,8 @@ class EtherscanTransactionStrategy extends TransactionHistoryStrategy {
     required this.pubkeyManager,
     http.Client? httpClient,
     String? baseUrl,
-  })  : _client = httpClient ?? http.Client(),
-        _protocolHelper = EtherscanProtocolHelper(baseUrl: baseUrl);
+  }) : _client = httpClient ?? http.Client(),
+       _protocolHelper = EtherscanProtocolHelper(baseUrl: baseUrl);
 
   final http.Client _client;
   final EtherscanProtocolHelper _protocolHelper;
@@ -23,9 +23,9 @@ class EtherscanTransactionStrategy extends TransactionHistoryStrategy {
 
   @override
   Set<Type> get supportedPaginationModes => {
-        PagePagination,
-        TransactionBasedPagination,
-      };
+    PagePagination,
+    TransactionBasedPagination,
+  };
 
   @override
   bool supportsAsset(Asset asset) => _protocolHelper.supportsProtocol(asset);
@@ -49,7 +49,8 @@ class EtherscanTransactionStrategy extends TransactionHistoryStrategy {
 
     validatePagination(pagination);
 
-    final url = _protocolHelper.getApiUrlForAsset(asset) ??
+    final url =
+        _protocolHelper.getApiUrlForAsset(asset) ??
         (throw UnsupportedError(
           'No API URL found for asset ${asset.id.toJson()}',
         ));
@@ -78,16 +79,17 @@ class EtherscanTransactionStrategy extends TransactionHistoryStrategy {
       // Apply pagination based on type
       final paginatedResults = switch (pagination) {
         final PagePagination p => _applyPagePagination(
-            allTransactions,
-            p.pageNumber,
-            p.itemsPerPage,
-          ),
+          allTransactions,
+          p.pageNumber,
+          p.itemsPerPage,
+        ),
         final TransactionBasedPagination t => _applyTransactionPagination(
-            allTransactions,
-            t.fromId,
-            t.itemCount,
-          ),
-        _ => throw UnsupportedError(
+          allTransactions,
+          t.fromId,
+          t.itemCount,
+        ),
+        _ =>
+          throw UnsupportedError(
             'Unsupported pagination type: ${pagination.runtimeType}',
           ),
       };
@@ -110,9 +112,7 @@ class EtherscanTransactionStrategy extends TransactionHistoryStrategy {
         transactions: paginatedResults.transactions,
       );
     } catch (e) {
-      throw HttpException(
-        'Error fetching transaction history: $e',
-      );
+      throw HttpException('Error fetching transaction history: $e');
     }
   }
 
@@ -152,12 +152,13 @@ class EtherscanTransactionStrategy extends TransactionHistoryStrategy {
             blockHeight: tx.value<int>('block_height'),
             confirmations: tx.value<int>('confirmations'),
             timestamp: tx.value<int>('timestamp'),
-            feeDetails: tx.valueOrNull<JsonMap>('fee_details') != null
-                ? FeeInfo.fromJson(
-                    tx.value<JsonMap>('fee_details')
-                      ..setIfAbsentOrEmpty('type', 'Eth'),
-                  )
-                : null,
+            feeDetails:
+                tx.valueOrNull<JsonMap>('fee_details') != null
+                    ? FeeInfo.fromJson(
+                      tx.value<JsonMap>('fee_details')
+                        ..setIfAbsentOrEmpty('type', 'Eth'),
+                    )
+                    : null,
             coin: coinId,
             internalId: tx.value<String>('internal_id'),
             memo: tx.valueOrNull<String>('memo'),
@@ -166,11 +167,8 @@ class EtherscanTransactionStrategy extends TransactionHistoryStrategy {
         .toList();
   }
 
-  ({
-    List<TransactionInfo> transactions,
-    int skipped,
-    int pageSize,
-  }) _applyPagePagination(
+  ({List<TransactionInfo> transactions, int skipped, int pageSize})
+  _applyPagePagination(
     List<TransactionInfo> transactions,
     int pageNumber,
     int itemsPerPage,
@@ -183,11 +181,8 @@ class EtherscanTransactionStrategy extends TransactionHistoryStrategy {
     );
   }
 
-  ({
-    List<TransactionInfo> transactions,
-    int skipped,
-    int pageSize,
-  }) _applyTransactionPagination(
+  ({List<TransactionInfo> transactions, int skipped, int pageSize})
+  _applyTransactionPagination(
     List<TransactionInfo> transactions,
     String fromId,
     int itemCount,
@@ -211,9 +206,8 @@ class EtherscanTransactionStrategy extends TransactionHistoryStrategy {
 
 /// Helper class for managing Etherscan protocol endpoints and URL construction
 class EtherscanProtocolHelper {
-  const EtherscanProtocolHelper({
-    String? baseUrl,
-  }) : _baseUrl = baseUrl ?? 'https://etherscan-proxy-v2.komodo.earth/api';
+  const EtherscanProtocolHelper({String? baseUrl})
+    : _baseUrl = baseUrl ?? 'https://etherscan-proxy-v2.komodo.earth/api';
 
   final String _baseUrl;
 
@@ -221,6 +215,12 @@ class EtherscanProtocolHelper {
   bool supportsProtocol(Asset asset) {
     return asset.protocol is Erc20Protocol && getApiUrlForAsset(asset) != null;
   }
+
+  /// Whether transaction history should also be fetched via mm2.
+  ///
+  /// When Etherscan does not support the provided [asset], transaction history
+  /// must fall back to mm2 RPC calls.
+  bool shouldEnableTransactionHistory(Asset asset) => !supportsProtocol(asset);
 
   /// Constructs the appropriate API URL for a given asset
   Uri? getApiUrlForAsset(Asset asset) {


### PR DESCRIPTION
## Summary
- when an asset uses a non-KDF transaction history strategy like Etherscan, disable `tx_history` during activation so KDF won't fetch history

## Testing
- `flutter analyze` *(fails: 2466 issues)*

------
https://chatgpt.com/codex/tasks/task_e_687e872666c083269582f46d716d21a2