### PR TITLE
fix launching path quoting

### DIFF
--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_local_executable.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_local_executable.dart
@@ -115,8 +115,11 @@ class KdfOperationsLocalExecutable implements IKdfOperations {
       final environment = Map<String, String>.of(Platform.environment)
         ..['MM_COINS_PATH'] = coinsConfigFile.path;
 
+      // Wrap the path in quotes when launching via shell to handle spaces
+      // or special characters like parentheses in the executable path.
+      final sanitizedPath = '"$executablePath"';
       final newProcess = await Process.start(
-        executablePath,
+        sanitizedPath,
         [sensitiveArgs.toJsonString()],
         environment: environment,
         runInShell: true,


### PR DESCRIPTION
## Summary
- quote executable path before launching under Process.start

## Testing
- `flutter analyze`
- `flutter pub get --offline`

------
https://chatgpt.com/codex/tasks/task_e_688373f3b3b083269bbc425eb2574546