### PR TITLE
feat(pubkeys): add list banned pubkeys method

### DIFF
--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/rpc_methods.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/rpc_methods.dart
@@ -52,6 +52,7 @@ export 'wallet/get_wallet_names_request.dart';
 export 'wallet/get_wallet_names_response.dart';
 export 'wallet/my_balance.dart';
 export 'wallet/unban_pubkeys.dart';
+export 'wallet/list_banned_pubkeys.dart';
 export 'withdrawal/send_raw_transaction_request.dart';
 export 'withdrawal/withdraw_request.dart';
 export 'withdrawal/withdrawal_rpc_namespace.dart';

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/wallet/list_banned_pubkeys.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/wallet/list_banned_pubkeys.dart
@@ -1,0 +1,69 @@
+import 'package:equatable/equatable.dart';
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+
+class ListBannedPubkeysRequest
+    extends BaseRequest<ListBannedPubkeysResponse, GeneralErrorResponse> {
+  ListBannedPubkeysRequest({required String rpcPass})
+    : super(method: 'list_banned_pubkeys', rpcPass: rpcPass, mmrpc: null);
+
+  @override
+  JsonMap toJson() => super.toJson();
+
+  @override
+  ListBannedPubkeysResponse parse(JsonMap json) =>
+      ListBannedPubkeysResponse.parse(json);
+}
+
+class ListBannedPubkeysResponse extends BaseResponse {
+  ListBannedPubkeysResponse({required super.mmrpc, required this.result});
+
+  factory ListBannedPubkeysResponse.parse(JsonMap json) =>
+      ListBannedPubkeysResponse(
+        mmrpc: json.valueOrNull<String>('mmrpc'),
+        result: json
+            .value<JsonMap>('result')
+            .map(
+              (k, v) => MapEntry(k, BannedPubkeyDetails.fromJson(v as JsonMap)),
+            ),
+      );
+
+  final Map<String, BannedPubkeyDetails> result;
+
+  @override
+  JsonMap toJson() => {
+    'mmrpc': mmrpc,
+    'result': result.map((k, v) => MapEntry(k, v.toJson())),
+  };
+}
+
+class BannedPubkeyDetails extends Equatable {
+  const BannedPubkeyDetails({
+    required this.type,
+    this.reason,
+    this.causedByEvent,
+    this.causedBySwap,
+  });
+
+  factory BannedPubkeyDetails.fromJson(JsonMap json) => BannedPubkeyDetails(
+    type: json.value<String>('type'),
+    reason: json.valueOrNull<String>('reason'),
+    causedByEvent: json.valueOrNull<JsonMap>('caused_by_event'),
+    causedBySwap: json.valueOrNull<String>('caused_by_swap'),
+  );
+
+  final String type;
+  final String? reason;
+  final JsonMap? causedByEvent;
+  final String? causedBySwap;
+
+  JsonMap toJson() => {
+    'type': type,
+    if (reason != null) 'reason': reason,
+    if (causedByEvent != null) 'caused_by_event': causedByEvent,
+    if (causedBySwap != null) 'caused_by_swap': causedBySwap,
+  };
+
+  @override
+  List<Object?> get props => [type, reason, causedByEvent, causedBySwap];
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods_library.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods_library.dart
@@ -103,6 +103,9 @@ class WalletMethods extends BaseRpcMethodNamespace {
     required UnbanBy unbanBy,
     String? rpcPass,
   }) => execute(UnbanPubkeysRequest(rpcPass: rpcPass ?? '', unbanBy: unbanBy));
+
+  Future<ListBannedPubkeysResponse> listBannedPubkeys([String? rpcPass]) =>
+      execute(ListBannedPubkeysRequest(rpcPass: rpcPass ?? ''));
 }
 
 /// KDF v2 Utility Methods not specific to any larger feature

--- a/packages/komodo_defi_sdk/lib/src/pubkeys/pubkey_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/pubkeys/pubkey_manager.dart
@@ -50,6 +50,12 @@ class PubkeyManager {
     return response.result;
   }
 
+  /// Retrieve a map of currently banned pubkeys
+  Future<Map<String, BannedPubkeyDetails>> listBannedPubkeys() async {
+    final response = await _client.rpc.wallet.listBannedPubkeys();
+    return response.result;
+  }
+
   Future<PubkeyStrategy> _resolvePubkeyStrategy(Asset asset) async {
     final currentUser = await _auth.currentUser;
     if (currentUser == null) {

--- a/packages/komodo_defi_types/lib/src/exported_rpc_types.dart
+++ b/packages/komodo_defi_types/lib/src/exported_rpc_types.dart
@@ -1,2 +1,8 @@
 export 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart'
-    show AddressFormat, BalanceInfo, UnbanBy, UnbanPubkeysResult, BannedPubkeyInfo;
+    show
+        AddressFormat,
+        BalanceInfo,
+        UnbanBy,
+        UnbanPubkeysResult,
+        BannedPubkeyInfo,
+        BannedPubkeyDetails;


### PR DESCRIPTION
## Summary
- implement `list_banned_pubkeys` request and response
- expose new RPC method and wire it into the wallet namespace
- add helper in `PubkeyManager` for listing banned pubkeys
- export new RPC types for SDK consumers

## Testing
- `flutter analyze` *(fails: CounterView etc. undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6888ea5146c083269349581dde786782