### PR TITLE
feat(types): parent display name suffix via subclass

### DIFF
--- a/packages/komodo_defi_types/lib/src/assets/asset_id.dart
+++ b/packages/komodo_defi_types/lib/src/assets/asset_id.dart
@@ -93,6 +93,22 @@ class AssetId extends Equatable {
         subClass == other.subClass &&
         chainId.formattedChainId == other.chainId.formattedChainId;
   }
+
+  /// A display-friendly name that disambiguates networks using the token
+  /// standard suffix from the asset `id` when present.
+  ///
+  /// Examples:
+  /// - id: `ETH-ARB20`, name: `Ethereum` -> `Ethereum (ARB20)`
+  /// - id: `USDT-ERC20`, name: `Tether USD` -> `Tether USD (ERC20)`
+  /// - id: `BTC`, name: `Bitcoin` -> `Bitcoin`
+  String get displayName {
+    // Only append suffix for top-level (parent) assets. Child assets already
+    // convey their network via parent linkage and UI badges.
+    if (isChildAsset) return name;
+    final String? suffix = subClass.tokenStandardSuffix;
+    if (suffix == null) return name;
+    return '$name ($suffix)';
+  }
 }
 
 extension AssetIdCacheKeyPrefix on AssetId {

--- a/packages/komodo_defi_types/lib/src/coin_classes/coin_subclasses.dart
+++ b/packages/komodo_defi_types/lib/src/coin_classes/coin_subclasses.dart
@@ -295,6 +295,54 @@ enum CoinSubClass {
   }
 }
 
+extension CoinSubClassTokenStandard on CoinSubClass {
+  /// Canonical short token/network standard suffix used for parent asset
+  /// disambiguation in display names. Returns null when no suffix should
+  /// be appended for the given subclass.
+  String? get tokenStandardSuffix {
+    switch (this) {
+      case CoinSubClass.erc20:
+        return 'ERC20';
+      case CoinSubClass.bep20:
+        return 'BEP20';
+      case CoinSubClass.qrc20:
+        return 'QRC20';
+      case CoinSubClass.ftm20:
+        return 'FTM20';
+      case CoinSubClass.arbitrum:
+        return 'ARB20';
+      case CoinSubClass.avx20:
+        return 'AVX20';
+      case CoinSubClass.matic:
+        return 'PLG20';
+      case CoinSubClass.moonriver:
+        return 'MVR20';
+      case CoinSubClass.krc20:
+        return 'KRC20';
+      case CoinSubClass.hrc20:
+        return 'HRC20';
+      case CoinSubClass.hecoChain:
+        return 'HCO20';
+      // Subclasses without a canonical short token/network standard suffix
+      case CoinSubClass.moonbeam:
+      case CoinSubClass.slp: // ignore: deprecated_member_use_from_same_package
+      case CoinSubClass.sia:
+      case CoinSubClass.smartChain:
+      case CoinSubClass.ethereumClassic:
+      case CoinSubClass.ubiq:
+      case CoinSubClass.utxo:
+      case CoinSubClass.smartBch:
+      case CoinSubClass.tendermint:
+      case CoinSubClass.tendermintToken:
+      case CoinSubClass.ewt:
+      case CoinSubClass.rskSmartBitcoin:
+      case CoinSubClass.zhtlc:
+      case CoinSubClass.unknown:
+        return null;
+    }
+  }
+}
+
 const Set<CoinSubClass> evmCoinSubClasses = {
   CoinSubClass.avx20,
   CoinSubClass.bep20,


### PR DESCRIPTION
Implements parent-chain disambiguation in SDK.

- Adds CoinSubClass.tokenStandardSuffix (exhaustive switch)
- Adds AssetId.displayName (parent-only) using tokenStandardSuffix
- Wallet uses id.displayName for UI; protocol pill shows "NATIVE" for parents
- Child assets unchanged; no impact on IDs/balances

Context: https://github.com/KomodoPlatform/komodo-wallet/pull/2988#issuecomment-3187197089
