### PR TITLE
chore(framework): update macOS build matching_pattern

### DIFF
--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -27,7 +27,7 @@
                 "path": "ios"
             },
             "macos": {
-                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-mac-arm64|kdf-macos-universal2-[a-f0-9]{7,40}|mm2-[a-f0-9]{7,40}-Darwin-Release)\\.zip$",
+                "matching_pattern": "^(?:kdf-macos-universal2-[a-f0-9]{7,40}|kdf_[a-f0-9]{7,40}-mac-universal)\\.zip$",
                 "matching_preference": [
                     "universal2",
                     "mac-arm64"


### PR DESCRIPTION
Update macOS build_config.json matching_pattern to support universal zips:

- kdf-macos-universal2-[a-f0-9]{7,40}
- kdf_[a-f0-9]{7,40}-mac-universal

Targets branch: dev

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates macOS build matching to only accept universal artifacts and drops legacy arm64/mm2 patterns.
> 
> - **Build Config (`packages/komodo_defi_framework/app_build/build_config.json`)**:
>   - **macOS**: Update `matching_pattern` to only match `kdf-macos-universal2-[a-f0-9]{7,40}` and `kdf_[a-f0-9]{7,40}-mac-universal`; remove previous `kdf_* -mac-arm64` and `mm2-*` patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d92a1712dd7f489c685af680dd5fbeddf9a70ca3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->