### PR TITLE
dds IRISTEST, NUCLEUSTEST & IRISTEST-IBC_NUCLEUSTEST as faucet coins

### DIFF
--- a/packages/komodo_defi_sdk/lib/komodo_defi_sdk.dart
+++ b/packages/komodo_defi_sdk/lib/komodo_defi_sdk.dart
@@ -38,6 +38,7 @@ export 'src/assets/_assets_index.dart' show AssetHdWalletAddressesExtension;
 export 'src/assets/asset_extensions.dart'
     show
         AssetFaucetExtension,
+        AssetIdFaucetExtension,
         AssetUnavailableErrorReasonExtension,
         AssetValidation;
 export 'src/assets/asset_pubkey_extensions.dart';

--- a/packages/komodo_defi_sdk/lib/src/assets/asset_extensions.dart
+++ b/packages/komodo_defi_sdk/lib/src/assets/asset_extensions.dart
@@ -12,8 +12,13 @@ final assetTickersWithFaucet = UnmodifiableListView([
 ]);
 
 extension AssetFaucetExtension on Asset {
-  // TODO: Implement faucet functionality in SDK
+  // TODO: Implement faucet functionality in SDK - using the faucet endpoint with hardcoded tickers as a fallback
+  // https://faucet.komodo.earth/faucet_coins 
   bool get hasFaucet => assetTickersWithFaucet.contains(id.symbol.configSymbol);
+}
+
+extension AssetIdFaucetExtension on AssetId {
+  bool get hasFaucet => assetTickersWithFaucet.contains(symbol.configSymbol);
 }
 
 /// Core extension providing asset validation and compatibility checks


### PR DESCRIPTION
These are supported by https://faucet.komodo.earth/faucet_balances

The `IRISTEST-IBC_NUCLEUSTEST` faucet will be funded once https://github.com/KomodoPlatform/coins/pull/1552 is merged