### PR TITLE
fix(sdk): reduce excessive get_enabled_coins RPC calls by fixing cache bypasses and increasing TTL

### DIFF
--- a/packages/komodo_defi_sdk/lib/src/activation/activation_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/activation/activation_manager.dart
@@ -108,6 +108,7 @@ class ActivationManager {
           _client,
           privKeyPolicy,
           _configService,
+          _activatedAssetsCache,
         );
 
         await for (final progress in activator.activate(
@@ -139,13 +140,8 @@ class ActivationManager {
   /// Check if asset and its children are already activated
   Future<ActivationProgress> _checkActivationStatus(_AssetGroup group) async {
     try {
-      final enabledCoins = await _client.rpc.generalActivation
-          .getEnabledCoins();
-      final enabledAssetIds = enabledCoins.result
-          .map((coin) => _assetLookup.findAssetsByConfigId(coin.ticker))
-          .expand((assets) => assets)
-          .map((asset) => asset.id)
-          .toSet();
+      // Use cache instead of direct RPC call to avoid excessive requests
+      final enabledAssetIds = await _activatedAssetsCache.getActivatedAssetIds();
 
       final isActive = enabledAssetIds.contains(group.primary.id);
       final childrenActive =

--- a/packages/komodo_defi_sdk/lib/src/activation/base_strategies/activation_strategy_factory.dart
+++ b/packages/komodo_defi_sdk/lib/src/activation/base_strategies/activation_strategy_factory.dart
@@ -1,6 +1,7 @@
 import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart';
 import 'package:komodo_defi_sdk/src/activation/_activation.dart';
 import 'package:komodo_defi_sdk/src/activation_config/activation_config_service.dart';
+import 'package:komodo_defi_sdk/src/assets/activated_assets_cache.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 
 /// Factory for creating the complete activation strategy stack
@@ -11,10 +12,12 @@ class ActivationStrategyFactory {
   /// [privKeyPolicy] The [PrivateKeyPolicy] to use for private key management.
   /// This is used for external wallet support. E.g. trezor, wallet connect, etc
   /// [configService] The [ActivationConfigService] for resolving activation configuration.
+  /// [activatedAssetsCache] The [ActivatedAssetsCache] to use for checking activation status.
   static SmartAssetActivator createStrategy(
     ApiClient client,
     PrivateKeyPolicy privKeyPolicy,
     ActivationConfigService configService,
+    ActivatedAssetsCache activatedAssetsCache,
   ) {
     return SmartAssetActivator(
       client,
@@ -34,6 +37,7 @@ class ActivationStrategyFactory {
         ZhtlcActivationStrategy(client, privKeyPolicy, configService),
         CustomErc20ActivationStrategy(client),
       ]),
+      activatedAssetsCache,
     );
   }
 }

--- a/packages/komodo_defi_sdk/lib/src/sdk/komodo_defi_sdk_config.dart
+++ b/packages/komodo_defi_sdk/lib/src/sdk/komodo_defi_sdk_config.dart
@@ -9,7 +9,7 @@ class KomodoDefiSdkConfig {
     this.preActivateCustomTokenAssets = true,
     this.maxPreActivationAttempts = 3,
     this.activationRetryDelay = const Duration(seconds: 2),
-    this.activatedAssetsCacheTtl = const Duration(seconds: 2),
+    this.activatedAssetsCacheTtl = const Duration(seconds: 10),
     this.marketDataConfig = const MarketDataConfig(),
   });
 


### PR DESCRIPTION
<img width="1280" height="367" alt="image" src="https://github.com/user-attachments/assets/5bcae860-780b-476f-b900-397111be3104" />

## Problem

The application was making excessive requests to the `get_enabled_coins` KDF RPC endpoint (**~90+ requests per second**), causing unnecessary load on the KDF server. Investigation revealed two issues:

1. **Cache bypasses**: Several code paths were calling `getEnabledCoins()` directly instead of using the `ActivatedAssetsCache`, completely bypassing the caching mechanism
2. **Short cache TTL**: The cache TTL was set to only 2 seconds, causing frequent cache misses and subsequent RPC calls

## Solution

### Fixed cache bypasses

1. **`ActivationManager._checkActivationStatus()`**: Replaced direct RPC call with `_activatedAssetsCache.getActivatedAssetIds()` to use the cache
2. **`SmartAssetActivator._isAssetActive()`**: 
   - Added `ActivatedAssetsCache` as a dependency to `SmartAssetActivator`
   - Replaced direct RPC call with cache lookup
   - Updated `ActivationStrategyFactory` to accept and pass the cache instance
   - Updated `ActivationManager` to pass the cache when creating activation strategies

### Increased cache TTL

- Changed default `activatedAssetsCacheTtl` from 2 seconds to 10 seconds in `KomodoDefiSdkConfig`
- This reduces cache misses while still maintaining reasonable freshness of activation status

## Impact

After these changes, all activation status checks now properly use the cached data, and the longer TTL significantly reduces the number of RPC calls to the KDF `get_enabled_coins` endpoint. The volume of requests has been substantially reduced from the previous ~90+ requests per second.