### PR TITLE
feat(migration): add legacy wallet migration package and SDK support

### DIFF
--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -65,7 +65,7 @@
   "coins": {
     "fetch_at_build_enabled": true,
     "update_commit_on_build": true,
-    "bundled_coins_repo_commit": "1d2a5c9c4d23416df2fa1c5e2f263a244a09704d",
+    "bundled_coins_repo_commit": "46587568ac5ed542544dc9bd68bab35d7d818cf2",
     "coins_repo_api_url": "https://api.github.com/repos/GLEECBTC/coins",
     "coins_repo_content_url": "https://raw.githubusercontent.com/GLEECBTC/coins",
     "coins_repo_branch": "master",

--- a/packages/komodo_defi_framework/lib/komodo_defi_framework.dart
+++ b/packages/komodo_defi_framework/lib/komodo_defi_framework.dart
@@ -23,6 +23,10 @@ export 'package:komodo_defi_framework/src/streaming/events/kdf_event.dart';
 export 'src/operations/kdf_operations_interface.dart';
 
 class KomodoDefiFramework implements ApiClient {
+  static const Duration _versionProbeTimeout = Duration(seconds: 2);
+  static const Duration _stopPollInterval = Duration(milliseconds: 250);
+  static const Duration _stopSettleDelay = Duration(milliseconds: 250);
+
   factory KomodoDefiFramework.create({
     required IKdfHostConfig hostConfig,
     void Function(String)? externalLogger,
@@ -162,24 +166,44 @@ class KomodoDefiFramework implements ApiClient {
     _log('Stopping KDF...');
     final result = await _kdfOperations.kdfStop();
     _log('KDF stop result: $result');
-    // Await a max of 5 seconds for KDF to stop. Check every 500ms.
-    for (var i = 0; i < 10; i++) {
-      await Future<void>.delayed(const Duration(milliseconds: 500));
-      if (!await isRunning()) {
-        break;
-      }
-      if (i == 9) {
-        throw Exception('Error stopping KDF: KDF did not stop in time.');
+
+    // Drop any stale keep-alive socket before verifying shutdown. Otherwise,
+    // the post-stop version() fallback can hang on Android while the native
+    // thread is already tearing down.
+    resetHttpClient();
+
+    // Wait for native status to settle without probing RPC over HTTP.
+    for (var i = 0; i < 20; i++) {
+      await Future<void>.delayed(_stopPollInterval);
+      final stillRunning = await isRunning(allowVersionFallback: false);
+      if (!stillRunning) {
+        await Future<void>.delayed(_stopSettleDelay);
+        if (!await isRunning(allowVersionFallback: false)) {
+          return result;
+        }
       }
     }
 
-    return result;
+    throw Exception('Error stopping KDF: KDF did not stop in time.');
   }
 
-  Future<bool> isRunning() async {
+  Future<bool> isRunning({bool allowVersionFallback = true}) async {
+    final nativeRunning = await _kdfOperations.isRunning();
+    if (nativeRunning) {
+      return true;
+    }
+
+    if (!allowVersionFallback) {
+      _log('KDF is not running.');
+      return false;
+    }
+
     final running =
-        await _kdfOperations.isRunning() ||
-        await _kdfOperations.version() != null;
+        await _kdfOperations.version().timeout(
+          _versionProbeTimeout,
+          onTimeout: () => null,
+        ) !=
+        null;
     if (!running) {
       _log('KDF is not running.');
     }
@@ -188,15 +212,23 @@ class KomodoDefiFramework implements ApiClient {
 
   Future<String?> version() async {
     final stopwatch = Stopwatch()..start();
-    _log('version(): Starting version RPC call via ${_kdfOperations.operationsName}');
+    _log(
+      'version(): Starting version RPC call via ${_kdfOperations.operationsName}',
+    );
     try {
-      final version = await _kdfOperations.version();
+      final version = await _kdfOperations.version().timeout(
+        _versionProbeTimeout,
+      );
       stopwatch.stop();
-      _log('version(): Completed in ${stopwatch.elapsedMilliseconds}ms, result=$version');
+      _log(
+        'version(): Completed in ${stopwatch.elapsedMilliseconds}ms, result=$version',
+      );
       return version;
     } catch (e) {
       stopwatch.stop();
-      _log('version(): Failed after ${stopwatch.elapsedMilliseconds}ms with error: $e');
+      _log(
+        'version(): Failed after ${stopwatch.elapsedMilliseconds}ms with error: $e',
+      );
       rethrow;
     }
   }
@@ -205,7 +237,7 @@ class KomodoDefiFramework implements ApiClient {
   /// Returns true if KDF is running and responsive, false otherwise.
   /// This is useful for detecting when KDF has become unavailable, especially
   /// on mobile platforms after app backgrounding.
-  /// 
+  ///
   /// IMPORTANT: This method ONLY relies on actual RPC verification (version() call)
   /// to avoid false positives where native status reports "running" but HTTP listener
   /// is not accepting connections (common after iOS backgrounding).
@@ -217,7 +249,7 @@ class KomodoDefiFramework implements ApiClient {
         _log('KDF health check failed: version call returned null');
         return false;
       }
-      
+
       _log('KDF health check passed: version=$versionCheck');
       return true;
     } catch (e) {
@@ -279,7 +311,7 @@ class KomodoDefiFramework implements ApiClient {
       return response;
     } catch (e) {
       stopwatch.stop();
-      
+
       // Detect transport-fatal SocketExceptions that indicate KDF is down/dying
       // errno 32 (EPIPE): Broken pipe - writing to socket whose peer closed
       // errno 54 (ECONNRESET): Connection reset by peer
@@ -287,18 +319,29 @@ class KomodoDefiFramework implements ApiClient {
       // errno 61 (ECONNREFUSED): Connection refused - no listener on port
       final errorString = e.toString().toLowerCase();
       final isSocketException = errorString.contains('socketexception');
-      final isFatalTransportError = isSocketException && (
-        errorString.contains('broken pipe') || errorString.contains('errno = 32') ||
-        errorString.contains('connection reset') || errorString.contains('errno = 54') ||
-        errorString.contains('operation timed out') || errorString.contains('errno = 60') ||
-        errorString.contains('connection refused') || errorString.contains('errno = 61')
-      );
+      final isFatalTransportError =
+          isSocketException &&
+          (errorString.contains('broken pipe') ||
+              errorString.contains('errno = 32') ||
+              errorString.contains('connection reset') ||
+              errorString.contains('errno = 54') ||
+              errorString.contains('operation timed out') ||
+              errorString.contains('errno = 60') ||
+              errorString.contains('connection refused') ||
+              errorString.contains('errno = 61'));
 
       if (isFatalTransportError) {
-        final errorType = errorString.contains('errno = 32') || errorString.contains('broken pipe') ? 'EPIPE (32)' :
-                         errorString.contains('errno = 54') || errorString.contains('connection reset') ? 'ECONNRESET (54)' :
-                         errorString.contains('errno = 60') || errorString.contains('operation timed out') ? 'ETIMEDOUT (60)' :
-                         'ECONNREFUSED (61)';
+        final errorType =
+            errorString.contains('errno = 32') ||
+                errorString.contains('broken pipe')
+            ? 'EPIPE (32)'
+            : errorString.contains('errno = 54') ||
+                  errorString.contains('connection reset')
+            ? 'ECONNRESET (54)'
+            : errorString.contains('errno = 60') ||
+                  errorString.contains('operation timed out')
+            ? 'ETIMEDOUT (60)'
+            : 'ECONNREFUSED (61)';
         _logger.severe(
           '[RPC] ${method ?? 'unknown'} failed: KDF transport error $errorType. '
           'Resetting HTTP client to drop stale connections.',

--- a/packages/komodo_defi_local_auth/lib/src/auth/auth_service.dart
+++ b/packages/komodo_defi_local_auth/lib/src/auth/auth_service.dart
@@ -151,6 +151,10 @@ class KdfAuthService implements IAuthService {
   List<KdfUser>? _usersCache;
   DateTime? _usersCacheTimestamp;
   final Duration _usersCacheTtl = const Duration(minutes: 5);
+  static const Duration _kdfRpcReadyTimeout = Duration(seconds: 15);
+  static const Duration _kdfRpcProbeTimeout = Duration(seconds: 2);
+  static const Duration _kdfRpcPollInterval = Duration(milliseconds: 250);
+  static const Duration _startupSensitiveRpcTimeout = Duration(seconds: 10);
 
   ApiClient get _client => _kdfFramework.client;
   late final methods = KomodoDefiRpcMethods(_client);
@@ -254,42 +258,85 @@ class KdfAuthService implements IAuthService {
     ),
     Mnemonic? mnemonic,
   }) async {
-    await _ensureKdfRunning();
+    _logger.info(
+      '[$_sessionId] register: Starting registration for wallet: $walletName',
+    );
+    final registerStopwatch = Stopwatch()..start();
 
-    await _runReadOperation(() async {
-      final walletExists = await _walletExists(walletName);
-      if (walletExists) {
-        throw AuthException(
-          'Wallet already exists',
-          type: AuthExceptionType.generalAuthError,
+    try {
+      final ensureStartStopwatch = Stopwatch()..start();
+      await _ensureKdfRunning();
+      ensureStartStopwatch.stop();
+      _logger.info(
+        '[$_sessionId] register: ensure no-auth start completed in '
+        '${ensureStartStopwatch.elapsedMilliseconds}ms',
+      );
+
+      final walletExistsStopwatch = Stopwatch()..start();
+      await _runReadOperation(() async {
+        final walletExists = await _walletExists(walletName);
+        if (walletExists) {
+          throw AuthException(
+            'Wallet already exists',
+            type: AuthExceptionType.generalAuthError,
+          );
+        }
+      });
+      walletExistsStopwatch.stop();
+      _logger.info(
+        '[$_sessionId] register: wallet existence read completed in '
+        '${walletExistsStopwatch.elapsedMilliseconds}ms',
+      );
+
+      // replaces the __assertWalletOrStop method - wait for read/write locks to
+      // be released here.
+      // can be used outside of a lock, since both functions are public-facing
+      // and manage their own read/write locks
+      final stopStopwatch = Stopwatch()..start();
+      if (await isSignedIn()) {
+        await signOut();
+        stopStopwatch.stop();
+        _logger.info(
+          '[$_sessionId] register: stop phase completed in '
+          '${stopStopwatch.elapsedMilliseconds}ms',
+        );
+      } else {
+        stopStopwatch.stop();
+        _logger.info(
+          '[$_sessionId] register: no active session to stop '
+          '(${stopStopwatch.elapsedMilliseconds}ms)',
         );
       }
-    });
 
-    // replaces the __assertWalletOrStop method - wait for read/write locks to
-    // be released here.
-    // can be used outside of a lock, since both functions are public-facing
-    // and manage their own read/write locks
-    if (await isSignedIn()) {
-      await signOut();
+      final config = await _generateStartupConfig(
+        walletName: walletName,
+        walletPassword: password,
+        allowRegistrations: true,
+        plaintextMnemonic: mnemonic?.plaintextMnemonic,
+        hdEnabled: options.derivationMethod == DerivationMethod.hdWallet,
+        allowWeakPassword: options.allowWeakPassword,
+      );
+
+      return _lockWriteOperation(() async {
+        final writePathStopwatch = Stopwatch()..start();
+        final isImported = mnemonic != null;
+        final currentUser = await _registerNewUser(config, options, isImported);
+        writePathStopwatch.stop();
+        _logger.info(
+          '[$_sessionId] register: registration write path completed in '
+          '${writePathStopwatch.elapsedMilliseconds}ms',
+        );
+        _emitAuthStateChange(currentUser);
+        _invalidateUsersCache();
+        return currentUser;
+      });
+    } finally {
+      registerStopwatch.stop();
+      _logger.info(
+        '[$_sessionId] register: Finished in '
+        '${registerStopwatch.elapsedMilliseconds}ms',
+      );
     }
-
-    final config = await _generateStartupConfig(
-      walletName: walletName,
-      walletPassword: password,
-      allowRegistrations: true,
-      plaintextMnemonic: mnemonic?.plaintextMnemonic,
-      hdEnabled: options.derivationMethod == DerivationMethod.hdWallet,
-      allowWeakPassword: options.allowWeakPassword,
-    );
-
-    return _lockWriteOperation(() async {
-      final isImported = mnemonic != null;
-      final currentUser = await _registerNewUser(config, options, isImported);
-      _emitAuthStateChange(currentUser);
-      _invalidateUsersCache();
-      return currentUser;
-    });
   }
 
   @override
@@ -304,7 +351,10 @@ class KdfAuthService implements IAuthService {
         return _usersCache!;
       }
 
-      final walletNames = await _client.rpc.wallet.getWalletNames();
+      final walletNames = await _runStartupSensitiveRpc(
+        phase: 'get_wallet_names',
+        operation: () => _client.rpc.wallet.getWalletNames(),
+      );
 
       final users = await Future.wait(
         walletNames.walletNames.map((name) async {
@@ -1006,12 +1056,14 @@ class KdfAuthService implements IAuthService {
         throw KdfExtensions._mapStartupErrorToAuthException(result);
       }
 
-      _logger.info('[$_sessionId] _forceStartKdf: Waiting for RPC to be up');
+      _kdfFramework.resetHttpClient();
+      _logger.info('[$_sessionId] _forceStartKdf: Waiting for RPC to be ready');
       final waitStopwatch = Stopwatch()..start();
-      await _waitUntilKdfRpcIsUp();
+      await _waitUntilKdfRpcReady();
       waitStopwatch.stop();
       _logger.info(
-        '[$_sessionId] _forceStartKdf: RPC is up after ${waitStopwatch.elapsedMilliseconds}ms',
+        '[$_sessionId] _forceStartKdf: RPC ready after '
+        '${waitStopwatch.elapsedMilliseconds}ms',
       );
     });
   }

--- a/packages/komodo_defi_local_auth/lib/src/auth/auth_service_auth_extension.dart
+++ b/packages/komodo_defi_local_auth/lib/src/auth/auth_service_auth_extension.dart
@@ -2,7 +2,17 @@ part of 'auth_service.dart';
 
 extension KdfAuthServiceAuthExtension on KdfAuthService {
   Future<KdfUser> _authenticateUser(KdfStartupConfig config) async {
+    _logger.info(
+      '[$_sessionId] _authenticateUser: Restarting KDF for '
+      '${config.walletName}',
+    );
+    final restartStopwatch = Stopwatch()..start();
     await _restartKdf(config);
+    restartStopwatch.stop();
+    _logger.info(
+      '[$_sessionId] _authenticateUser: auth start + readiness verify '
+      'completed in ${restartStopwatch.elapsedMilliseconds}ms',
+    );
     final status = await _kdfFramework.kdfMainStatus();
     if (status != MainStatus.rpcIsUp) {
       throw AuthException(
@@ -13,7 +23,13 @@ extension KdfAuthServiceAuthExtension on KdfAuthService {
 
     // use the internal function here, which isn't read-protected, to avoid
     // deadlocks if used within a write-lock
+    final activeUserStopwatch = Stopwatch()..start();
     var currentUser = await _getActiveUser();
+    activeUserStopwatch.stop();
+    _logger.info(
+      '[$_sessionId] _authenticateUser: first authenticated RPC completed in '
+      '${activeUserStopwatch.elapsedMilliseconds}ms',
+    );
     if (currentUser == null) {
       throw AuthException(
         'No user signed in',
@@ -46,7 +62,17 @@ extension KdfAuthServiceAuthExtension on KdfAuthService {
     AuthOptions authOptions,
     bool isImported,
   ) async {
+    _logger.info(
+      '[$_sessionId] _registerNewUser: Restarting KDF for '
+      '${config.walletName}',
+    );
+    final restartStopwatch = Stopwatch()..start();
     await _restartKdf(config);
+    restartStopwatch.stop();
+    _logger.info(
+      '[$_sessionId] _registerNewUser: auth start + readiness verify '
+      'completed in ${restartStopwatch.elapsedMilliseconds}ms',
+    );
     final status = await _kdfFramework.kdfMainStatus();
     if (status != MainStatus.rpcIsUp) {
       throw AuthException(
@@ -56,13 +82,25 @@ extension KdfAuthServiceAuthExtension on KdfAuthService {
     }
 
     final walletId = WalletId.fromName(config.walletName!, authOptions);
+    final seedValidationStopwatch = Stopwatch()..start();
     final isBip39Seed = await _isSeedBip39Compatible(config);
+    seedValidationStopwatch.stop();
+    _logger.info(
+      '[$_sessionId] _registerNewUser: seed validation pipeline completed '
+      'in ${seedValidationStopwatch.elapsedMilliseconds}ms',
+    );
     final currentUser = KdfUser(
       walletId: walletId,
       isBip39Seed: isBip39Seed,
       metadata: {'isImported': isImported},
     );
+    final secureStorageStopwatch = Stopwatch()..start();
     await _secureStorage.saveUser(currentUser);
+    secureStorageStopwatch.stop();
+    _logger.info(
+      '[$_sessionId] _registerNewUser: secure-storage save completed in '
+      '${secureStorageStopwatch.elapsedMilliseconds}ms',
+    );
 
     // Do not allow authentication to proceed for HD wallets if the seed is not
     // BIP39 compatible.
@@ -79,9 +117,15 @@ extension KdfAuthServiceAuthExtension on KdfAuthService {
   /// Checks if the seed is a valid BIP39 seed phrase.
   /// Throws [AuthException] if the seed could not be obtained from KDF.
   Future<bool> _isSeedBip39Compatible(KdfStartupConfig config) async {
+    final mnemonicStopwatch = Stopwatch()..start();
     final plaintext = await _getMnemonic(
       encrypted: false,
       walletPassword: config.walletPassword,
+    );
+    mnemonicStopwatch.stop();
+    _logger.info(
+      '[$_sessionId] _registerNewUser: first authenticated RPC '
+      '(get_mnemonic) completed in ${mnemonicStopwatch.elapsedMilliseconds}ms',
     );
 
     if (plaintext.plaintextMnemonic == null) {
@@ -91,9 +135,15 @@ extension KdfAuthServiceAuthExtension on KdfAuthService {
       );
     }
 
+    final validationStopwatch = Stopwatch()..start();
     final validator = MnemonicValidator();
     await validator.init();
     final isBip39 = validator.validateBip39(plaintext.plaintextMnemonic!);
+    validationStopwatch.stop();
+    _logger.info(
+      '[$_sessionId] _registerNewUser: seed validation completed in '
+      '${validationStopwatch.elapsedMilliseconds}ms',
+    );
     return isBip39;
   }
 

--- a/packages/komodo_defi_local_auth/lib/src/auth/auth_service_kdf_extension.dart
+++ b/packages/komodo_defi_local_auth/lib/src/auth/auth_service_kdf_extension.dart
@@ -13,8 +13,10 @@ extension KdfExtensions on KdfAuthService {
       return null;
     }
 
-    final activeWallet =
-        (await _client.rpc.wallet.getWalletNames()).activatedWallet;
+    final activeWallet = (await _runStartupSensitiveRpc(
+      phase: 'active wallet read',
+      operation: () => _client.rpc.wallet.getWalletNames(),
+    )).activatedWallet;
     if (activeWallet == null) {
       return null;
     }
@@ -39,14 +41,19 @@ extension KdfExtensions on KdfAuthService {
       );
     }
 
-    final response = await _kdfFramework.client.executeRpc({
-      'mmrpc': '2.0',
-      'method': 'get_mnemonic',
-      'params': {
-        'format': encrypted ? 'encrypted' : 'plaintext',
-        if (!encrypted) 'password': walletPassword,
+    final response = await _runStartupSensitiveRpc<JsonMap>(
+      phase: 'get_mnemonic',
+      operation: () async {
+        return _kdfFramework.client.executeRpc({
+          'mmrpc': '2.0',
+          'method': 'get_mnemonic',
+          'params': {
+            'format': encrypted ? 'encrypted' : 'plaintext',
+            if (!encrypted) 'password': walletPassword,
+          },
+        });
       },
-    });
+    );
 
     if (response is JsonRpcErrorResponse) {
       throw AuthException(
@@ -60,6 +67,7 @@ extension KdfExtensions on KdfAuthService {
 
   Future<void> _stopKdf() async {
     await _kdfFramework.kdfStop();
+    _kdfFramework.resetHttpClient();
     _authStateController.add(null);
   }
 
@@ -68,22 +76,54 @@ extension KdfExtensions on KdfAuthService {
   Future<void> _ensureKdfRunning() async {
     if (!await _kdfFramework.isRunning()) {
       await _lockWriteOperation(() async {
-        await _kdfFramework.startKdf(await _noAuthConfig);
-        await _waitUntilKdfRpcIsUp();
+        final startStopwatch = Stopwatch()..start();
+        final kdfResult = await _kdfFramework.startKdf(await _noAuthConfig);
+        startStopwatch.stop();
+        _logger.info(
+          '[$_sessionId] _ensureKdfRunning: startKdf(no-auth) returned '
+          '${kdfResult.name} in ${startStopwatch.elapsedMilliseconds}ms',
+        );
+
+        if (!kdfResult.isStartingOrAlreadyRunning()) {
+          throw _mapStartupErrorToAuthException(kdfResult);
+        }
+
+        _kdfFramework.resetHttpClient();
+        await _waitUntilKdfRpcReady();
       });
     }
   }
 
   // consider moving to kdf api
   Future<void> _restartKdf(KdfStartupConfig config) async {
+    final stopStopwatch = Stopwatch()..start();
     await _stopKdf();
+    stopStopwatch.stop();
+    _logger.info(
+      '[$_sessionId] _restartKdf: stop phase completed in '
+      '${stopStopwatch.elapsedMilliseconds}ms',
+    );
+
+    final startStopwatch = Stopwatch()..start();
     final kdfResult = await _kdfFramework.startKdf(config);
+    startStopwatch.stop();
+    _logger.info(
+      '[$_sessionId] _restartKdf: auth start returned ${kdfResult.name} in '
+      '${startStopwatch.elapsedMilliseconds}ms',
+    );
 
     if (!kdfResult.isStartingOrAlreadyRunning()) {
       throw _mapStartupErrorToAuthException(kdfResult);
     }
 
-    await _waitUntilKdfRpcIsUp();
+    _kdfFramework.resetHttpClient();
+    final readyStopwatch = Stopwatch()..start();
+    await _waitUntilKdfRpcReady();
+    readyStopwatch.stop();
+    _logger.info(
+      '[$_sessionId] _restartKdf: readiness verify completed in '
+      '${readyStopwatch.elapsedMilliseconds}ms',
+    );
   }
 
   static AuthException _mapStartupErrorToAuthException(
@@ -140,26 +180,88 @@ extension KdfExtensions on KdfAuthService {
     }
   }
 
-  Future<void> _waitUntilKdfRpcIsUp({
-    Duration timeout = const Duration(seconds: 5),
-    bool throwOnTimeout = false,
+  Future<void> _waitUntilKdfRpcReady({
+    Duration timeout = KdfAuthService._kdfRpcReadyTimeout,
   }) async {
     final stopwatch = Stopwatch()..start();
 
     while (stopwatch.elapsed < timeout) {
-      final status = await _kdfFramework.kdfMainStatus();
+      final status = await _kdfFramework.kdfMainStatus().timeout(
+        KdfAuthService._kdfRpcProbeTimeout,
+        onTimeout: () => MainStatus.notRunning,
+      );
       if (status == MainStatus.rpcIsUp) {
-        return;
+        final version = await _kdfFramework.version().timeout(
+          KdfAuthService._kdfRpcProbeTimeout,
+          onTimeout: () => null,
+        );
+        if (version != null) {
+          _logger.info(
+            '[$_sessionId] _waitUntilKdfRpcReady: RPC ready in '
+            '${stopwatch.elapsedMilliseconds}ms',
+          );
+          return;
+        }
       }
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      await Future<void>.delayed(KdfAuthService._kdfRpcPollInterval);
     }
 
-    if (throwOnTimeout) {
-      throw AuthException(
-        'Timeout waiting for KDF RPC to start',
-        type: AuthExceptionType.generalAuthError,
+    throw AuthException(
+      'KDF RPC did not become ready within ${timeout.inSeconds} seconds',
+      type: AuthExceptionType.apiConnectionError,
+    );
+  }
+
+  Future<T> _runStartupSensitiveRpc<T>({
+    required String phase,
+    required Future<T> Function() operation,
+  }) async {
+    Future<T> runAttempt() =>
+        operation().timeout(KdfAuthService._startupSensitiveRpcTimeout);
+
+    try {
+      return await runAttempt();
+    } catch (error, stackTrace) {
+      if (!_shouldRecoverStartupSensitiveRpc(error)) {
+        rethrow;
+      }
+
+      _logger.warning(
+        '[$_sessionId] _runStartupSensitiveRpc: $phase failed on first '
+        'attempt, resetting HTTP client and retrying',
+        error,
+        stackTrace,
       );
+      _kdfFramework.resetHttpClient();
+      await _waitUntilKdfRpcReady();
+
+      try {
+        return await runAttempt();
+      } catch (retryError, retryStackTrace) {
+        if (!_shouldRecoverStartupSensitiveRpc(retryError)) {
+          rethrow;
+        }
+
+        _logger.severe(
+          '[$_sessionId] _runStartupSensitiveRpc: $phase failed after retry',
+          retryError,
+          retryStackTrace,
+        );
+        throw AuthException(
+          'KDF RPC unavailable during $phase',
+          type: AuthExceptionType.apiConnectionError,
+          details: {'phase': phase, 'cause': retryError.toString()},
+        );
+      }
     }
+  }
+
+  bool _shouldRecoverStartupSensitiveRpc(Object error) {
+    return error is TimeoutException ||
+        error is SocketException ||
+        error is HttpException ||
+        error is HandshakeException;
   }
 
   Future<KdfStartupConfig> _generateStartupConfig({

--- a/packages/komodo_defi_local_auth/lib/src/auth/auth_service_kdf_extension.dart
+++ b/packages/komodo_defi_local_auth/lib/src/auth/auth_service_kdf_extension.dart
@@ -191,16 +191,33 @@ extension KdfExtensions on KdfAuthService {
         onTimeout: () => MainStatus.notRunning,
       );
       if (status == MainStatus.rpcIsUp) {
-        final version = await _kdfFramework.version().timeout(
-          KdfAuthService._kdfRpcProbeTimeout,
-          onTimeout: () => null,
-        );
-        if (version != null) {
-          _logger.info(
-            '[$_sessionId] _waitUntilKdfRpcReady: RPC ready in '
-            '${stopwatch.elapsedMilliseconds}ms',
+        try {
+          final version = await _kdfFramework.version().timeout(
+            KdfAuthService._kdfRpcProbeTimeout,
+            onTimeout: () => null,
           );
-          return;
+          if (version != null) {
+            _logger.info(
+              '[$_sessionId] _waitUntilKdfRpcReady: RPC ready in '
+              '${stopwatch.elapsedMilliseconds}ms',
+            );
+            return;
+          }
+        } on SocketException catch (e) {
+          _logger.fine(
+            '[$_sessionId] _waitUntilKdfRpcReady: version probe transport '
+            'error (will retry): $e',
+          );
+        } on HttpException catch (e) {
+          _logger.fine(
+            '[$_sessionId] _waitUntilKdfRpcReady: version probe transport '
+            'error (will retry): $e',
+          );
+        } on HandshakeException catch (e) {
+          _logger.fine(
+            '[$_sessionId] _waitUntilKdfRpcReady: version probe transport '
+            'error (will retry): $e',
+          );
         }
       }
 

--- a/packages/komodo_defi_rpc_methods/lib/src/common_structures/activation/activation_params/activation_params.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/common_structures/activation/activation_params/activation_params.dart
@@ -411,8 +411,11 @@ class ActivationRpcData {
   /// Maximum number of electrum servers to keep connected. Defaults to 1.
   final int? maxConnected;
 
-  /// ZHTLC coins only. Optional, defaults to two days ago. Defines where to start
-  /// scanning blockchain data upon initial activation.
+  /// ZHTLC coins only. Optional. Defines where to start scanning blockchain
+  /// data on activation when provided by the client.
+  ///
+  /// If omitted, backend-side behavior applies (for example resuming from
+  /// persisted sync state or using backend defaults).
   ///
   /// Supported values:
   /// - Earliest: start from the coin's `sapling_activation_height`

--- a/packages/komodo_defi_sdk/lib/komodo_defi_sdk.dart
+++ b/packages/komodo_defi_sdk/lib/komodo_defi_sdk.dart
@@ -45,6 +45,8 @@ export 'src/activation_config/activation_config_service.dart'
         InMemoryKeyValueStore,
         JsonActivationConfigRepository,
         WalletIdResolver,
+        ZhtlcRecurringSyncMode,
+        ZhtlcRecurringSyncPolicy,
         ZhtlcUserConfig;
 export 'src/activation_config/hive_activation_config_repository.dart'
     show HiveActivationConfigRepository;

--- a/packages/komodo_defi_sdk/lib/src/activation/protocol_strategies/zhtlc_activation_strategy.dart
+++ b/packages/komodo_defi_sdk/lib/src/activation/protocol_strategies/zhtlc_activation_strategy.dart
@@ -4,8 +4,8 @@
 
 import 'dart:convert';
 import 'dart:developer' show log;
-import 'package:komodo_defi_framework/komodo_defi_framework.dart';
 
+import 'package:komodo_defi_framework/komodo_defi_framework.dart';
 import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart';
 import 'package:komodo_defi_sdk/src/activation/_activation.dart';
 import 'package:komodo_defi_sdk/src/activation/protocol_strategies/zhtlc_activation_progress.dart';
@@ -81,8 +81,9 @@ class ZhtlcActivationStrategy extends ProtocolActivationStrategy {
             privKeyPolicy: privKeyPolicy,
           );
 
-      // Apply one-shot sync_params only when explicitly provided via config form
-      // right before activation. This avoids caching and unintended rewinds.
+      // Apply sync params only when explicitly requested as a one-shot
+      // override. If absent, omit sync_params so backend resume/default sync
+      // behavior is used.
       if (params.mode?.rpcData != null) {
         final oneShotSync = await configService.takeOneShotSyncParams(asset.id);
         if (oneShotSync != null) {
@@ -106,15 +107,25 @@ class ZhtlcActivationStrategy extends ProtocolActivationStrategy {
       // Debug logging for ZHTLC activation
       if (KdfLoggingConfig.verboseLogging) {
         log(
-        '[RPC] Activating ZHTLC coin: ${asset.id.id}',
-        name: 'ZhtlcActivationStrategy',
-      );
+          '[RPC] Activating ZHTLC coin: ${asset.id.id}',
+          name: 'ZhtlcActivationStrategy',
+        );
       }
       if (KdfLoggingConfig.verboseLogging) {
+        final activationLogPayload = <String, dynamic>{
+          'ticker': asset.id.id,
+          'protocol': asset.protocol.subClass.formatted,
+          'activation_params': params.toRpcParams(),
+          'zcash_params_path': userConfig.zcashParamsPath,
+          'scan_blocks_per_iteration': userConfig.scanBlocksPerIteration,
+          'scan_interval_ms': userConfig.scanIntervalMs,
+          'polling_interval_ms': effectivePollingInterval.inMilliseconds,
+          'priv_key_policy': privKeyPolicy.toJson(),
+        };
         log(
-        '[RPC] Activation parameters: ${jsonEncode({'ticker': asset.id.id, 'protocol': asset.protocol.subClass.formatted, 'activation_params': params.toRpcParams(), 'zcash_params_path': userConfig.zcashParamsPath, 'scan_blocks_per_iteration': userConfig.scanBlocksPerIteration, 'scan_interval_ms': userConfig.scanIntervalMs, 'polling_interval_ms': effectivePollingInterval.inMilliseconds, 'priv_key_policy': privKeyPolicy.toJson()})}',
-        name: 'ZhtlcActivationStrategy',
-      );
+          '[RPC] Activation parameters: ${jsonEncode(activationLogPayload)}',
+          name: 'ZhtlcActivationStrategy',
+        );
       }
 
       // Initialize task and watch via TaskShepherd
@@ -167,7 +178,7 @@ class ZhtlcActivationStrategy extends ProtocolActivationStrategy {
           detail: detail,
         );
       }
-    } catch (e, stack) {
+    } on Object catch (e, stack) {
       yield ActivationProgressZhtlc.failure(e, stack);
     }
   }

--- a/packages/komodo_defi_sdk/lib/src/activation_config/activation_config_service.dart
+++ b/packages/komodo_defi_sdk/lib/src/activation_config/activation_config_service.dart
@@ -1,13 +1,144 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:hive_ce/hive.dart';
 import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
-import 'package:komodo_defi_local_auth/komodo_defi_local_auth.dart';
 
 typedef JsonMap = Map<String, dynamic>;
+
+enum ZhtlcRecurringSyncMode {
+  recentTransactions,
+  earliest,
+  height,
+  date;
+
+  static ZhtlcRecurringSyncMode? tryParse(String? value) {
+    switch (value) {
+      case 'recent_transactions':
+        return ZhtlcRecurringSyncMode.recentTransactions;
+      case 'earliest':
+        return ZhtlcRecurringSyncMode.earliest;
+      case 'height':
+        return ZhtlcRecurringSyncMode.height;
+      case 'date':
+        return ZhtlcRecurringSyncMode.date;
+      default:
+        return null;
+    }
+  }
+
+  String get jsonValue => switch (this) {
+    ZhtlcRecurringSyncMode.recentTransactions => 'recent_transactions',
+    ZhtlcRecurringSyncMode.earliest => 'earliest',
+    ZhtlcRecurringSyncMode.height => 'height',
+    ZhtlcRecurringSyncMode.date => 'date',
+  };
+}
+
+/// Persisted recurring sync policy for ZHTLC wallet activations.
+class ZhtlcRecurringSyncPolicy {
+  ZhtlcRecurringSyncPolicy._({
+    required this.mode,
+    this.height,
+    this.unixTimestamp,
+  }) : assert(switch (mode) {
+         ZhtlcRecurringSyncMode.recentTransactions ||
+         ZhtlcRecurringSyncMode.earliest =>
+           height == null && unixTimestamp == null,
+         ZhtlcRecurringSyncMode.height => height != null,
+         ZhtlcRecurringSyncMode.date => unixTimestamp != null,
+       }, 'Recurring sync policy data does not match its mode.');
+
+  factory ZhtlcRecurringSyncPolicy.recentTransactions() =>
+      ZhtlcRecurringSyncPolicy._(
+        mode: ZhtlcRecurringSyncMode.recentTransactions,
+      );
+
+  factory ZhtlcRecurringSyncPolicy.earliest() =>
+      ZhtlcRecurringSyncPolicy._(mode: ZhtlcRecurringSyncMode.earliest);
+
+  factory ZhtlcRecurringSyncPolicy.height(int height) =>
+      ZhtlcRecurringSyncPolicy._(
+        mode: ZhtlcRecurringSyncMode.height,
+        height: height,
+      );
+
+  factory ZhtlcRecurringSyncPolicy.date(int unixTimestamp) =>
+      ZhtlcRecurringSyncPolicy._(
+        mode: ZhtlcRecurringSyncMode.date,
+        unixTimestamp: unixTimestamp,
+      );
+
+  factory ZhtlcRecurringSyncPolicy.fromJson(JsonMap json) {
+    final mode = ZhtlcRecurringSyncMode.tryParse(
+      json.valueOrNull<String>('mode'),
+    );
+    if (mode == null) {
+      throw ArgumentError.value(
+        json['mode'],
+        'json.mode',
+        'Unsupported recurring ZHTLC sync policy mode',
+      );
+    }
+
+    return switch (mode) {
+      ZhtlcRecurringSyncMode.recentTransactions =>
+        ZhtlcRecurringSyncPolicy.recentTransactions(),
+      ZhtlcRecurringSyncMode.earliest => ZhtlcRecurringSyncPolicy.earliest(),
+      ZhtlcRecurringSyncMode.height => ZhtlcRecurringSyncPolicy.height(
+        json.value<int>('height'),
+      ),
+      ZhtlcRecurringSyncMode.date => ZhtlcRecurringSyncPolicy.date(
+        json.value<int>('unixTimestamp'),
+      ),
+    };
+  }
+
+  factory ZhtlcRecurringSyncPolicy.fromSyncParams(ZhtlcSyncParams syncParams) {
+    if (syncParams.isEarliest) {
+      return ZhtlcRecurringSyncPolicy.earliest();
+    }
+    if (syncParams.height != null) {
+      return ZhtlcRecurringSyncPolicy.height(syncParams.height!);
+    }
+    if (syncParams.date != null) {
+      return ZhtlcRecurringSyncPolicy.date(syncParams.date!);
+    }
+    throw ArgumentError.value(
+      syncParams,
+      'syncParams',
+      'Unsupported ZHTLC sync params payload',
+    );
+  }
+
+  final ZhtlcRecurringSyncMode mode;
+  final int? height;
+  final int? unixTimestamp;
+
+  JsonMap toJson() => <String, dynamic>{
+    'mode': mode.jsonValue,
+    if (height != null) 'height': height,
+    if (unixTimestamp != null) 'unixTimestamp': unixTimestamp,
+  };
+
+  ZhtlcSyncParams toSyncParams({DateTime? now}) {
+    return switch (mode) {
+      ZhtlcRecurringSyncMode.recentTransactions => ZhtlcSyncParams.date(
+        (now ?? DateTime.now())
+                .toUtc()
+                .subtract(const Duration(days: 2))
+                .millisecondsSinceEpoch ~/
+            1000,
+      ),
+      ZhtlcRecurringSyncMode.earliest => ZhtlcSyncParams.earliest(),
+      ZhtlcRecurringSyncMode.height => ZhtlcSyncParams.height(height!),
+      ZhtlcRecurringSyncMode.date => ZhtlcSyncParams.date(unixTimestamp!),
+    };
+  }
+}
 
 /// Simple key-value store abstraction for persisting activation configs.
 abstract class KeyValueStore {
@@ -45,6 +176,7 @@ class ZhtlcUserConfig {
     this.scanBlocksPerIteration = 1000,
     this.scanIntervalMs = 0,
     this.taskStatusPollingIntervalMs,
+    this.recurringSyncPolicy,
     this.syncParams,
   });
 
@@ -52,13 +184,39 @@ class ZhtlcUserConfig {
   final int scanBlocksPerIteration;
   final int scanIntervalMs;
   final int? taskStatusPollingIntervalMs;
+  final ZhtlcRecurringSyncPolicy? recurringSyncPolicy;
+
   /// Optional, accepted for backward compatibility. Not persisted.
   /// If provided to saveZhtlcConfig, it will be applied as a one-shot
   /// sync override for the next activation and then discarded.
   final ZhtlcSyncParams? syncParams;
-  // Sync params are no longer persisted here; they are supplied one-shot
-  // via ActivationConfigService at activation time when the user requests
-  // an intentional resync.
+  // Sync params are supplied one-shot via ActivationConfigService when the
+  // user requests an immediate resync. Recurring sync behavior is persisted
+  // separately via [recurringSyncPolicy].
+
+  ZhtlcUserConfig copyWith({
+    String? zcashParamsPath,
+    int? scanBlocksPerIteration,
+    int? scanIntervalMs,
+    int? taskStatusPollingIntervalMs,
+    ZhtlcRecurringSyncPolicy? recurringSyncPolicy,
+    bool clearRecurringSyncPolicy = false,
+    ZhtlcSyncParams? syncParams,
+    bool clearSyncParams = false,
+  }) {
+    return ZhtlcUserConfig(
+      zcashParamsPath: zcashParamsPath ?? this.zcashParamsPath,
+      scanBlocksPerIteration:
+          scanBlocksPerIteration ?? this.scanBlocksPerIteration,
+      scanIntervalMs: scanIntervalMs ?? this.scanIntervalMs,
+      taskStatusPollingIntervalMs:
+          taskStatusPollingIntervalMs ?? this.taskStatusPollingIntervalMs,
+      recurringSyncPolicy: clearRecurringSyncPolicy
+          ? null
+          : recurringSyncPolicy ?? this.recurringSyncPolicy,
+      syncParams: clearSyncParams ? null : syncParams ?? this.syncParams,
+    );
+  }
 
   JsonMap toJson() => {
     'zcashParamsPath': zcashParamsPath,
@@ -66,6 +224,8 @@ class ZhtlcUserConfig {
     'scanIntervalMs': scanIntervalMs,
     if (taskStatusPollingIntervalMs != null)
       'taskStatusPollingIntervalMs': taskStatusPollingIntervalMs,
+    if (recurringSyncPolicy != null)
+      'recurringSyncPolicy': recurringSyncPolicy!.toJson(),
   };
 
   static ZhtlcUserConfig fromJson(JsonMap json) => ZhtlcUserConfig(
@@ -76,6 +236,12 @@ class ZhtlcUserConfig {
     taskStatusPollingIntervalMs: json.valueOrNull<int>(
       'taskStatusPollingIntervalMs',
     ),
+    recurringSyncPolicy:
+        json.valueOrNull<JsonMap>('recurringSyncPolicy') == null
+        ? null
+        : ZhtlcRecurringSyncPolicy.fromJson(
+            json.value<JsonMap>('recurringSyncPolicy'),
+          ),
   );
 }
 
@@ -249,8 +415,12 @@ class ActivationConfigService {
         onTimeout: () => null,
       );
       if (result == null) return null;
-      await repo.saveConfig(walletId, id, result);
-      return result;
+      if (result.syncParams != null) {
+        _oneShotSyncParams[key] = result.syncParams;
+      }
+      final normalizedConfig = _normalizeConfigForPersistence(result);
+      await repo.saveConfig(walletId, id, normalizedConfig);
+      return normalizedConfig;
     } finally {
       _awaitingControllers.remove(key);
     }
@@ -258,12 +428,12 @@ class ActivationConfigService {
 
   Future<void> saveZhtlcConfig(AssetId id, ZhtlcUserConfig config) async {
     final walletId = await _requireActiveWallet();
-    // If legacy callers provide syncParams in the config, convert it to
-    // a one-shot sync override and do not persist it.
-    if (config.syncParams != null) {
-      _oneShotSyncParams[_WalletAssetKey(walletId, id)] = config.syncParams;
+    final oneShotSyncParams = config.syncParams;
+    final normalizedConfig = _normalizeConfigForPersistence(config);
+    if (oneShotSyncParams != null) {
+      _oneShotSyncParams[_WalletAssetKey(walletId, id)] = oneShotSyncParams;
     }
-    await repo.saveConfig(walletId, id, config);
+    await repo.saveConfig(walletId, id, normalizedConfig);
   }
 
   Future<void> submitZhtlc(AssetId id, ZhtlcUserConfig config) async {
@@ -290,6 +460,19 @@ class ActivationConfigService {
     return value;
   }
 
+  ZhtlcUserConfig _normalizeConfigForPersistence(ZhtlcUserConfig config) {
+    final recurringSyncPolicy =
+        config.recurringSyncPolicy ??
+        (config.syncParams == null
+            ? null
+            : ZhtlcRecurringSyncPolicy.fromSyncParams(config.syncParams!));
+
+    return config.copyWith(
+      recurringSyncPolicy: recurringSyncPolicy,
+      clearSyncParams: true,
+    );
+  }
+
   /// Clears all one-shot sync params for the specified wallet.
   /// This should be called when a user signs out to prevent stale one-shot
   /// params from being applied on the next activation after re-login.
@@ -307,8 +490,9 @@ class ActivationConfigService {
       {};
 }
 
+@immutable
 class _WalletAssetKey {
-  _WalletAssetKey(this.walletId, this.assetId);
+  const _WalletAssetKey(this.walletId, this.assetId);
 
   final WalletId walletId;
   final AssetId assetId;

--- a/packages/komodo_defi_sdk/lib/src/errors/sdk_error_mapper.dart
+++ b/packages/komodo_defi_sdk/lib/src/errors/sdk_error_mapper.dart
@@ -229,6 +229,7 @@ class _AuthExceptionHandler extends SdkErrorHandler {
       case AuthExceptionType.alreadySignedIn:
       case AuthExceptionType.registrationNotAllowed:
       case AuthExceptionType.internalError:
+      case AuthExceptionType.legacyWalletAlreadyMigrated:
         return _build(
           code: SdkErrorCode.general,
           category: SdkErrorCategory.auth,

--- a/packages/komodo_defi_sdk/test/activation/zhtlc_activation_strategy_test.dart
+++ b/packages/komodo_defi_sdk/test/activation/zhtlc_activation_strategy_test.dart
@@ -1,0 +1,155 @@
+import 'dart:collection';
+
+import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart';
+import 'package:komodo_defi_sdk/src/activation/protocol_strategies/zhtlc_activation_strategy.dart';
+import 'package:komodo_defi_sdk/src/activation_config/activation_config_service.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'package:test/test.dart';
+
+class _QueueApiClient implements ApiClient {
+  _QueueApiClient({required Map<String, List<JsonMap>> responsesByMethod})
+    : _responsesByMethod = {
+        for (final entry in responsesByMethod.entries)
+          entry.key: Queue<JsonMap>.from(entry.value),
+      };
+
+  final Map<String, Queue<JsonMap>> _responsesByMethod;
+  final List<JsonMap> requests = <JsonMap>[];
+
+  @override
+  Future<JsonMap> executeRpc(JsonMap request) async {
+    requests.add(Map<String, dynamic>.from(request));
+    final method = request['method'] as String?;
+    if (method == null || method.isEmpty) {
+      throw StateError('Missing RPC method in request: $request');
+    }
+
+    final queue = _responsesByMethod[method];
+    if (queue == null || queue.isEmpty) {
+      throw StateError('No queued response for method $method');
+    }
+
+    return queue.removeFirst();
+  }
+}
+
+Asset _createZhtlcAsset() {
+  final protocol = ZhtlcProtocol.fromJson(const {
+    'type': 'ZHTLC',
+    'light_wallet_d_servers': ['https://lightd.example'],
+    'electrum_servers': [
+      {'url': 'electrum.example:50002', 'protocol': 'SSL'},
+    ],
+  });
+
+  return Asset(
+    id: AssetId(
+      id: 'ARRR',
+      name: 'Pirate Chain',
+      symbol: AssetSymbol(assetConfigId: 'ARRR'),
+      chainId: AssetChainId(chainId: 1),
+      derivationPath: null,
+      subClass: CoinSubClass.zhtlc,
+    ),
+    protocol: protocol,
+    isWalletOnly: false,
+    signMessagePrefix: null,
+  );
+}
+
+void main() {
+  group('ZhtlcActivationStrategy', () {
+    test('applies one-shot sync params once and omits sync_params '
+        'on subsequent activations', () async {
+      final walletId = WalletId.fromName(
+        'Test Wallet',
+        const AuthOptions(derivationMethod: DerivationMethod.iguana),
+      );
+      final configService = ActivationConfigService(
+        JsonActivationConfigRepository(InMemoryKeyValueStore()),
+        walletIdResolver: () async => walletId,
+      );
+      final asset = _createZhtlcAsset();
+
+      await configService.saveZhtlcConfig(
+        asset.id,
+        ZhtlcUserConfig(
+          zcashParamsPath: '/zcash-params',
+          recurringSyncPolicy: ZhtlcRecurringSyncPolicy.recentTransactions(),
+          syncParams: ZhtlcSyncParams.height(123456),
+        ),
+      );
+
+      final client = _QueueApiClient(
+        responsesByMethod: {
+          'task::enable_z_coin::init': [
+            {
+              'mmrpc': '2.0',
+              'result': {'task_id': 1},
+            },
+            {
+              'mmrpc': '2.0',
+              'result': {'task_id': 2},
+            },
+          ],
+          'task::enable_z_coin::status': [
+            {
+              'mmrpc': '2.0',
+              'result': {'status': 'Ok', 'details': 'done'},
+            },
+            {
+              'mmrpc': '2.0',
+              'result': {'status': 'Ok', 'details': 'done'},
+            },
+          ],
+        },
+      );
+      final strategy = ZhtlcActivationStrategy(
+        client,
+        const PrivateKeyPolicy.contextPrivKey(),
+        configService,
+        pollingInterval: const Duration(milliseconds: 1),
+      );
+
+      await strategy.activate(asset).toList();
+      await strategy.activate(asset).toList();
+
+      final initRequests = client.requests
+          .where((request) => request['method'] == 'task::enable_z_coin::init')
+          .toList(growable: false);
+      expect(initRequests, hasLength(2));
+
+      final firstRpcData =
+          ((initRequests.first['params']
+                      as Map<String, dynamic>)['activation_params']
+                  as Map<String, dynamic>)['mode']
+              as Map<String, dynamic>;
+      final firstModeRpcData = firstRpcData['rpc_data'] as Map<String, dynamic>;
+      expect(firstModeRpcData['sync_params'], <String, dynamic>{
+        'height': 123456,
+      });
+
+      final secondRpcData =
+          ((initRequests.last['params']
+                      as Map<String, dynamic>)['activation_params']
+                  as Map<String, dynamic>)['mode']
+              as Map<String, dynamic>;
+      final secondModeRpcData =
+          secondRpcData['rpc_data'] as Map<String, dynamic>;
+      expect(secondModeRpcData.containsKey('sync_params'), isFalse);
+
+      final savedConfig = await configService.getSavedZhtlc(asset.id);
+      expect(savedConfig, isNotNull);
+      expect(savedConfig?.syncParams, isNull);
+      expect(
+        savedConfig?.recurringSyncPolicy?.mode,
+        ZhtlcRecurringSyncMode.recentTransactions,
+      );
+
+      final remainingOneShot = await configService.takeOneShotSyncParams(
+        asset.id,
+      );
+      expect(remainingOneShot, isNull);
+    });
+  });
+}

--- a/packages/komodo_defi_sdk/test/src/activation_config/activation_config_service_test.dart
+++ b/packages/komodo_defi_sdk/test/src/activation_config/activation_config_service_test.dart
@@ -1,0 +1,75 @@
+import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart';
+import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ZhtlcRecurringSyncPolicy', () {
+    test('recentTransactions resolves to a runtime date sync param', () {
+      final policy = ZhtlcRecurringSyncPolicy.recentTransactions();
+      final now = DateTime.utc(2026, 4, 10, 12);
+      final syncParams = policy.toSyncParams(now: now);
+
+      expect(syncParams.isEarliest, isFalse);
+      expect(syncParams.height, isNull);
+      expect(
+        syncParams.date,
+        now.subtract(const Duration(days: 2)).millisecondsSinceEpoch ~/ 1000,
+      );
+    });
+
+    test('serializes and deserializes date policies', () {
+      final policy = ZhtlcRecurringSyncPolicy.date(1775659200);
+
+      final decoded = ZhtlcRecurringSyncPolicy.fromJson(policy.toJson());
+
+      expect(decoded.mode, ZhtlcRecurringSyncMode.date);
+      expect(decoded.unixTimestamp, 1775659200);
+    });
+  });
+
+  group('ActivationConfigService', () {
+    test('saveZhtlcConfig persists recurring policy and stores one-shot '
+        'sync params', () async {
+      final walletId = WalletId.fromName(
+        'Test Wallet',
+        const AuthOptions(derivationMethod: DerivationMethod.iguana),
+      );
+      final assetId = AssetId(
+        id: 'ARRR',
+        name: 'Pirate Chain',
+        symbol: AssetSymbol(assetConfigId: 'ARRR'),
+        chainId: AssetChainId(chainId: 777, decimalsValue: 8),
+        derivationPath: null,
+        subClass: CoinSubClass.zhtlc,
+      );
+      final service = ActivationConfigService(
+        JsonActivationConfigRepository(InMemoryKeyValueStore()),
+        walletIdResolver: () async => walletId,
+      );
+
+      await service.saveZhtlcConfig(
+        assetId,
+        ZhtlcUserConfig(
+          zcashParamsPath: '/zcash-params',
+          syncParams: ZhtlcSyncParams.height(123456),
+        ),
+      );
+
+      final savedConfig = await service.getSavedZhtlc(assetId);
+      final oneShotSync = await service.takeOneShotSyncParams(assetId);
+      final consumedSync = await service.takeOneShotSyncParams(assetId);
+
+      expect(savedConfig, isNotNull);
+      expect(savedConfig?.syncParams, isNull);
+      expect(savedConfig?.zcashParamsPath, '/zcash-params');
+      expect(
+        savedConfig?.recurringSyncPolicy?.mode,
+        ZhtlcRecurringSyncMode.height,
+      );
+      expect(savedConfig?.recurringSyncPolicy?.height, 123456);
+      expect(oneShotSync?.height, 123456);
+      expect(consumedSync, isNull);
+    });
+  });
+}

--- a/packages/komodo_defi_types/lib/src/auth/exceptions/auth_exception.dart
+++ b/packages/komodo_defi_types/lib/src/auth/exceptions/auth_exception.dart
@@ -14,20 +14,26 @@ enum AuthExceptionType {
   registrationNotAllowed,
   internalError,
   apiConnectionError,
+
+  /// Legacy wallet already has a migrated KDF counterpart.
+  legacyWalletAlreadyMigrated,
 }
 
 class AuthException implements Exception {
-  AuthException(
-    this.message, {
-    required this.type,
-    this.details = const {},
-  });
+  AuthException(this.message, {required this.type, this.details = const {}});
 
   // Common exception constructors convenience methods
   AuthException.notSignedIn()
-      : this('Not signed in', type: AuthExceptionType.unauthorized);
+    : this('Not signed in', type: AuthExceptionType.unauthorized);
   AuthException.notFound()
-      : this('Not found', type: AuthExceptionType.walletNotFound);
+    : this('Not found', type: AuthExceptionType.walletNotFound);
+
+  AuthException.legacyWalletAlreadyMigrated(String migratedWalletName)
+    : this(
+        'Legacy wallet already migrated',
+        type: AuthExceptionType.legacyWalletAlreadyMigrated,
+        details: {'migratedWalletName': migratedWalletName},
+      );
 
   /// The error message.
   final String message;
@@ -95,49 +101,46 @@ class AuthException implements Exception {
         return matchingPatterns[AuthExceptionType.registrationNotAllowed]!;
       case AuthExceptionType.apiConnectionError:
         return matchingPatterns[AuthExceptionType.apiConnectionError]!;
-      // The following types don't originate from the API, so we return empty arrays
+      // The following types don't originate from the API, so we return empty
+      // arrays.
       case AuthExceptionType.generalAuthError:
       case AuthExceptionType.unauthorized:
       case AuthExceptionType.alreadySignedIn:
       case AuthExceptionType.internalError:
       case AuthExceptionType.invalidBip39Mnemonic:
+      case AuthExceptionType.legacyWalletAlreadyMigrated:
         return [];
     }
   }
 
   static Map<AuthExceptionType, List<String>> get matchingPatterns => {
-        AuthExceptionType.incorrectPassword: [
-          'Incorrect wallet password',
-          'Error generating or decrypting mnemonic',
-          'HMAC',
-          'Error decrypting mnemonic: HMAC error: MAC tag mismatch',
-          'MAC tag mismatch',
-          'Error decrypting mnemonic',
-        ],
-        AuthExceptionType.walletAlreadyRunning: [
-          'Wallet is already running',
-        ],
-        AuthExceptionType.walletStartFailed: [
-          'Failed to start KDF',
-        ],
-        AuthExceptionType.walletNotFound: [
-          'Wallet does not exist',
-          'No wallet found with the given name',
-        ],
-        AuthExceptionType.walletAlreadyExists: [
-          'Wallet already exists',
-          'A wallet with this name already exists',
-        ],
-        AuthExceptionType.registrationNotAllowed: [
-          'wallet creation is disabled',
-        ],
-        AuthExceptionType.apiConnectionError: [
-          'Connection refused',
-          'Connection timed out',
-        ],
-        // We don't include patterns for the following types as they don't originate from the API
-        // AuthExceptionType.generalAuthError
-        // AuthExceptionType.unauthorized
-        // AuthExceptionType.alreadySignedIn
-      };
+    AuthExceptionType.incorrectPassword: [
+      'Incorrect wallet password',
+      'Error generating or decrypting mnemonic',
+      'HMAC',
+      'Error decrypting mnemonic: HMAC error: MAC tag mismatch',
+      'MAC tag mismatch',
+      'Error decrypting mnemonic',
+    ],
+    AuthExceptionType.walletAlreadyRunning: ['Wallet is already running'],
+    AuthExceptionType.walletStartFailed: ['Failed to start KDF'],
+    AuthExceptionType.walletNotFound: [
+      'Wallet does not exist',
+      'No wallet found with the given name',
+    ],
+    AuthExceptionType.walletAlreadyExists: [
+      'Wallet already exists',
+      'A wallet with this name already exists',
+    ],
+    AuthExceptionType.registrationNotAllowed: ['wallet creation is disabled'],
+    AuthExceptionType.apiConnectionError: [
+      'Connection refused',
+      'Connection timed out',
+    ],
+    // We don't include patterns for the following types as they don't
+    // originate from the API.
+    // AuthExceptionType.generalAuthError
+    // AuthExceptionType.unauthorized
+    // AuthExceptionType.alreadySignedIn
+  };
 }

--- a/packages/komodo_legacy_wallet_migration/.gitignore
+++ b/packages/komodo_legacy_wallet_migration/.gitignore
@@ -1,0 +1,44 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# VSCode related
+.vscode/*
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+pubspec.lock
+
+# Web related
+lib/generated_plugin_registrant.dart
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Test related
+coverage

--- a/packages/komodo_legacy_wallet_migration/LICENSE
+++ b/packages/komodo_legacy_wallet_migration/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c)  
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/komodo_legacy_wallet_migration/README.md
+++ b/packages/komodo_legacy_wallet_migration/README.md
@@ -1,0 +1,67 @@
+# Komodo Legacy Wallet Migration
+
+[![style: very good analysis][very_good_analysis_badge]][very_good_analysis_link]
+[![Powered by Mason](https://img.shields.io/endpoint?url=https%3A%2F%2Ftinyurl.com%2Fmason-badge)](https://github.com/felangel/mason)
+[![License: MIT][license_badge]][license_link]
+
+Legacy wallet migration utilities for Komodo/Gleec SDK apps.
+
+## Installation 💻
+
+**❗ In order to start using Komodo Legacy Wallet Migration you must have the [Flutter SDK][flutter_install_link] installed on your machine.**
+
+Install via `flutter pub add`:
+
+```sh
+dart pub add komodo_legacy_wallet_migration
+```
+
+---
+
+## Continuous Integration 🤖
+
+Komodo Legacy Wallet Migration comes with a built-in [GitHub Actions workflow][github_actions_link] powered by [Very Good Workflows][very_good_workflows_link] but you can also add your preferred CI/CD solution.
+
+Out of the box, on each pull request and push, the CI `formats`, `lints`, and `tests` the code. This ensures the code remains consistent and behaves correctly as you add functionality or make changes. The project uses [Very Good Analysis][very_good_analysis_link] for a strict set of analysis options used by our team. Code coverage is enforced using the [Very Good Workflows][very_good_coverage_link].
+
+---
+
+## Running Tests 🧪
+
+For first time users, install the [very_good_cli][very_good_cli_link]:
+
+```sh
+dart pub global activate very_good_cli
+```
+
+To run all unit tests:
+
+```sh
+very_good test --coverage
+```
+
+To view the generated coverage report you can use [lcov](https://github.com/linux-test-project/lcov).
+
+```sh
+# Generate Coverage Report
+genhtml coverage/lcov.info -o coverage/
+
+# Open Coverage Report
+open coverage/index.html
+```
+
+[flutter_install_link]: https://docs.flutter.dev/get-started/install
+[github_actions_link]: https://docs.github.com/en/actions/learn-github-actions
+[license_badge]: https://img.shields.io/badge/license-MIT-blue.svg
+[license_link]: https://opensource.org/licenses/MIT
+[logo_black]: https://raw.githubusercontent.com/VGVentures/very_good_brand/main/styles/README/vgv_logo_black.png#gh-light-mode-only
+[logo_white]: https://raw.githubusercontent.com/VGVentures/very_good_brand/main/styles/README/vgv_logo_white.png#gh-dark-mode-only
+[mason_link]: https://github.com/felangel/mason
+[very_good_analysis_badge]: https://img.shields.io/badge/style-very_good_analysis-B22C89.svg
+[very_good_analysis_link]: https://pub.dev/packages/very_good_analysis
+[very_good_cli_link]: https://pub.dev/packages/very_good_cli
+[very_good_coverage_link]: https://github.com/marketplace/actions/very-good-coverage
+[very_good_ventures_link]: https://verygood.ventures
+[very_good_ventures_link_light]: https://verygood.ventures#gh-light-mode-only
+[very_good_ventures_link_dark]: https://verygood.ventures#gh-dark-mode-only
+[very_good_workflows_link]: https://github.com/VeryGoodOpenSource/very_good_workflows

--- a/packages/komodo_legacy_wallet_migration/analysis_options.yaml
+++ b/packages/komodo_legacy_wallet_migration/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.yaml

--- a/packages/komodo_legacy_wallet_migration/lib/komodo_legacy_wallet_migration.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/komodo_legacy_wallet_migration.dart
@@ -1,4 +1,6 @@
-/// Legacy wallet migration utilities for Komodo/Gleec SDK apps.
-library;
-
+// Legacy wallet migration utilities for Komodo/Gleec SDK apps.
 export 'src/komodo_legacy_wallet_migration.dart';
+export 'src/models/legacy_wallet_cleanup_result.dart';
+export 'src/models/legacy_wallet_migration_exception.dart';
+export 'src/models/legacy_wallet_record.dart';
+export 'src/models/legacy_wallet_secrets.dart';

--- a/packages/komodo_legacy_wallet_migration/lib/komodo_legacy_wallet_migration.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/komodo_legacy_wallet_migration.dart
@@ -1,0 +1,4 @@
+/// Legacy wallet migration utilities for Komodo/Gleec SDK apps.
+library;
+
+export 'src/komodo_legacy_wallet_migration.dart';

--- a/packages/komodo_legacy_wallet_migration/lib/src/adapters/legacy_password_verifier.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/adapters/legacy_password_verifier.dart
@@ -1,4 +1,8 @@
-import 'package:dargon2_flutter/dargon2_flutter.dart';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:pointycastle/key_derivators/api.dart';
+import 'package:pointycastle/key_derivators/argon2.dart';
 
 /// Verifies a legacy native wallet password against the stored seed hash.
 // ignore: one_member_abstracts
@@ -11,6 +15,9 @@ abstract interface class LegacyPasswordVerifier {
 }
 
 /// Argon2id-based verifier for legacy native wallet seed passwords.
+///
+/// Uses pointycastle's pure-Dart Argon2 implementation, which is compatible
+/// with all Dart platforms including Flutter Web WASM.
 class Argon2LegacyPasswordVerifier implements LegacyPasswordVerifier {
   /// Creates an Argon2-based verifier.
   const Argon2LegacyPasswordVerifier();
@@ -21,13 +28,116 @@ class Argon2LegacyPasswordVerifier implements LegacyPasswordVerifier {
     required String encodedHash,
   }) async {
     try {
-      return await argon2.verifyHashString(
-        password,
-        encodedHash,
-        type: Argon2Type.id,
+      final parsed = _parsePhcEncodedHash(encodedHash);
+      if (parsed == null) return false;
+
+      final params = Argon2Parameters(
+        parsed.type,
+        parsed.salt,
+        desiredKeyLength: parsed.hash.length,
+        iterations: parsed.timeCost,
+        memory: parsed.memoryCost,
+        lanes: parsed.parallelism,
+        version: parsed.version,
       );
+
+      final generator = Argon2BytesGenerator()..init(params);
+      final derived = generator.process(
+        Uint8List.fromList(utf8.encode(password)),
+      );
+
+      return _constantTimeEquals(derived, parsed.hash);
     } on Object {
       return false;
     }
   }
+
+  /// Parses the PHC string format used by Argon2 reference implementations.
+  ///
+  /// Format:
+  /// `$argon2<type>$v=<ver>$m=<mem>,t=<time>,p=<par>$<salt>$<hash>`
+  static _ParsedArgon2Hash? _parsePhcEncodedHash(String encoded) {
+    final parts = encoded.split(r'$');
+    // Expect ['', 'argon2id', 'v=19', 'm=...,t=...,p=...', '<salt>', '<hash>']
+    if (parts.length < 6) return null;
+
+    final int type;
+    switch (parts[1]) {
+      case 'argon2d':
+        type = Argon2Parameters.ARGON2_d;
+      case 'argon2i':
+        type = Argon2Parameters.ARGON2_i;
+      case 'argon2id':
+        type = Argon2Parameters.ARGON2_id;
+      default:
+        return null;
+    }
+
+    final versionMatch = RegExp(r'^v=(\d+)$').firstMatch(parts[2]);
+    if (versionMatch == null) return null;
+    final version = int.parse(versionMatch.group(1)!);
+
+    final paramsMatch =
+        RegExp(r'^m=(\d+),t=(\d+),p=(\d+)$').firstMatch(parts[3]);
+    if (paramsMatch == null) return null;
+    final memoryCost = int.parse(paramsMatch.group(1)!);
+    final timeCost = int.parse(paramsMatch.group(2)!);
+    final parallelism = int.parse(paramsMatch.group(3)!);
+
+    final salt = _decodeUnpaddedBase64(parts[4]);
+    final hash = _decodeUnpaddedBase64(parts[5]);
+    if (salt == null || hash == null) return null;
+
+    return _ParsedArgon2Hash(
+      type: type,
+      version: version,
+      memoryCost: memoryCost,
+      timeCost: timeCost,
+      parallelism: parallelism,
+      salt: salt,
+      hash: hash,
+    );
+  }
+
+  static Uint8List? _decodeUnpaddedBase64(String input) {
+    try {
+      final padded = switch (input.length % 4) {
+        2 => '$input==',
+        3 => '$input=',
+        _ => input,
+      };
+      return base64Decode(padded);
+    } on Object {
+      return null;
+    }
+  }
+
+  static bool _constantTimeEquals(Uint8List a, Uint8List b) {
+    if (a.length != b.length) return false;
+    var result = 0;
+    for (var i = 0; i < a.length; i++) {
+      result |= a[i] ^ b[i];
+    }
+    return result == 0;
+  }
+}
+
+class _ParsedArgon2Hash {
+  const _ParsedArgon2Hash({
+    required this.type,
+    required this.version,
+    required this.memoryCost,
+    required this.timeCost,
+    required this.parallelism,
+    required this.salt,
+    required this.hash,
+  });
+
+  final int type;
+  final int version;
+  final int memoryCost;
+  final int timeCost;
+  final int parallelism;
+  final Uint8List salt;
+  final Uint8List hash;
 }

--- a/packages/komodo_legacy_wallet_migration/lib/src/adapters/legacy_password_verifier.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/adapters/legacy_password_verifier.dart
@@ -1,0 +1,33 @@
+import 'package:dargon2_flutter/dargon2_flutter.dart';
+
+/// Verifies a legacy native wallet password against the stored seed hash.
+// ignore: one_member_abstracts
+abstract interface class LegacyPasswordVerifier {
+  /// Returns `true` when [password] matches the legacy [encodedHash].
+  Future<bool> verifySeedPassword({
+    required String password,
+    required String encodedHash,
+  });
+}
+
+/// Argon2id-based verifier for legacy native wallet seed passwords.
+class Argon2LegacyPasswordVerifier implements LegacyPasswordVerifier {
+  /// Creates an Argon2-based verifier.
+  const Argon2LegacyPasswordVerifier();
+
+  @override
+  Future<bool> verifySeedPassword({
+    required String password,
+    required String encodedHash,
+  }) async {
+    try {
+      return await argon2.verifyHashString(
+        password,
+        encodedHash,
+        type: Argon2Type.id,
+      );
+    } on Object {
+      return false;
+    }
+  }
+}

--- a/packages/komodo_legacy_wallet_migration/lib/src/adapters/legacy_secure_storage.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/adapters/legacy_secure_storage.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// Minimal secure-storage interface for legacy native wallet migration.
+abstract interface class LegacySecureStorage {
+  /// Reads the raw value stored under [key].
+  Future<String?> read(String key);
+
+  /// Deletes the value stored under [key].
+  Future<void> delete(String key);
+}
+
+/// `flutter_secure_storage` adapter used by the production migration service.
+class FlutterLegacySecureStorage implements LegacySecureStorage {
+  /// Creates a secure-storage adapter.
+  FlutterLegacySecureStorage({FlutterSecureStorage? storage})
+    : _storage =
+          storage ??
+          const FlutterSecureStorage(
+            // The current app/plugin version still needs this option so legacy
+            // migration opens the same Android secure-storage backend.
+            // ignore: deprecated_member_use
+            aOptions: AndroidOptions(encryptedSharedPreferences: true),
+            iOptions: IOSOptions(
+              accessibility: KeychainAccessibility.first_unlock,
+            ),
+            mOptions: MacOsOptions(
+              accessibility: KeychainAccessibility.first_unlock,
+            ),
+          );
+
+  final FlutterSecureStorage _storage;
+
+  @override
+  Future<String?> read(String key) {
+    return _storage.read(key: key);
+  }
+
+  @override
+  Future<void> delete(String key) {
+    return _storage.delete(key: key);
+  }
+}

--- a/packages/komodo_legacy_wallet_migration/lib/src/adapters/legacy_shared_preferences_store.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/adapters/legacy_shared_preferences_store.dart
@@ -1,0 +1,29 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Minimal shared-preferences interface for legacy native wallet migration.
+abstract interface class LegacySharedPreferencesStore {
+  /// Reads the raw value stored under [key].
+  Future<Object?> read(String key);
+
+  /// Deletes the value stored under [key].
+  Future<void> delete(String key);
+}
+
+/// `shared_preferences` adapter used by the production migration service.
+class FlutterLegacySharedPreferencesStore
+    implements LegacySharedPreferencesStore {
+  Future<SharedPreferences> _instance() => SharedPreferences.getInstance();
+
+  @override
+  Future<Object?> read(String key) async {
+    final prefs = await _instance();
+    await prefs.reload();
+    return prefs.get(key);
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    final prefs = await _instance();
+    await prefs.remove(key);
+  }
+}

--- a/packages/komodo_legacy_wallet_migration/lib/src/adapters/legacy_wallet_metadata_store.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/adapters/legacy_wallet_metadata_store.dart
@@ -1,0 +1,188 @@
+import 'package:komodo_legacy_wallet_migration/src/models/legacy_wallet_migration_exception.dart';
+import 'package:komodo_legacy_wallet_migration/src/models/legacy_wallet_record.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+
+/// Minimal metadata-store interface for legacy native wallet migration.
+abstract interface class LegacyWalletMetadataStore {
+  /// Lists legacy wallets discovered in the native wallet database.
+  Future<List<LegacyWalletRecord>> listWallets();
+
+  /// Deletes all persisted database rows associated with [walletId].
+  Future<void> deleteWalletData({required String walletId});
+}
+
+/// `sqflite` adapter for reading the legacy native wallet database.
+class SqfliteLegacyWalletMetadataStore implements LegacyWalletMetadataStore {
+  /// Creates a metadata store backed by the legacy `AtomicDEX.db` database.
+  SqfliteLegacyWalletMetadataStore({
+    Future<String> Function()? documentsPathProvider,
+  }) : _documentsPathProvider =
+           documentsPathProvider ?? _defaultDocumentsPathProvider;
+
+  final Future<String> Function() _documentsPathProvider;
+
+  static Future<String> _defaultDocumentsPathProvider() async {
+    final directory = await getApplicationDocumentsDirectory();
+    return directory.path;
+  }
+
+  Future<String> _databasePath() async {
+    final documentsPath = await _documentsPathProvider();
+    return p.join(documentsPath, 'AtomicDEX.db');
+  }
+
+  @override
+  Future<List<LegacyWalletRecord>> listWallets() async {
+    try {
+      final databasePath = await _databasePath();
+      if (!await databaseExists(databasePath)) {
+        return const <LegacyWalletRecord>[];
+      }
+
+      final database = await openDatabase(databasePath, readOnly: true);
+      try {
+        final walletRows = await database.query(
+          'Wallet',
+          columns: [
+            'id',
+            'name',
+            'activate_pin_protection',
+            'activate_bio_protection',
+            'switch_pin_log_out_on_exit',
+            'enable_camo',
+            'is_camo_active',
+            'camo_fraction',
+            'camo_balance',
+            'camo_session_started_at',
+          ],
+        );
+        final currentWalletRows = await database.query(
+          'CurrentWallet',
+          columns: ['id'],
+        );
+        final activatedCoinRows = await database.query(
+          'ListOfCoinsActivated',
+          columns: ['wallet_id', 'coins'],
+        );
+
+        final currentWalletIds = currentWalletRows
+            .map((row) => row['id'])
+            .whereType<String>()
+            .toSet();
+        final activatedCoinsByWalletId = <String, List<String>>{
+          for (final row in activatedCoinRows)
+            if (row['wallet_id'] is String)
+              row['wallet_id']! as String: _parseActivatedCoins(row['coins']),
+        };
+
+        return walletRows
+            .map(
+              (row) => LegacyWalletRecord(
+                walletId: row['id'] as String? ?? '',
+                walletName: row['name'] as String? ?? '',
+                activatedCoins:
+                    activatedCoinsByWalletId[row['id'] as String? ?? ''] ??
+                    const <String>[],
+                isCurrentWallet: currentWalletIds.contains(row['id']),
+                walletExtras: _parseWalletExtras(row),
+              ),
+            )
+            .where((wallet) => wallet.walletId.isNotEmpty)
+            .toList(growable: false);
+      } finally {
+        await database.close();
+      }
+    } on Object catch (error) {
+      throw LegacyWalletMigrationException.storageAccessError(
+        'Failed to read legacy wallet metadata: $error',
+      );
+    }
+  }
+
+  @override
+  Future<void> deleteWalletData({required String walletId}) async {
+    try {
+      final databasePath = await _databasePath();
+      if (!await databaseExists(databasePath)) {
+        return;
+      }
+
+      final database = await openDatabase(databasePath);
+      try {
+        await database.transaction((txn) async {
+          await txn.delete('Wallet', where: 'id = ?', whereArgs: [walletId]);
+          await txn.delete(
+            'CurrentWallet',
+            where: 'id = ?',
+            whereArgs: [walletId],
+          );
+          await txn.delete(
+            'ListOfCoinsActivated',
+            where: 'wallet_id = ?',
+            whereArgs: [walletId],
+          );
+          await txn.delete(
+            'WalletSnapshot',
+            where: 'wallet_id = ?',
+            whereArgs: [walletId],
+          );
+        });
+      } finally {
+        await database.close();
+      }
+    } on Object catch (error) {
+      throw LegacyWalletMigrationException.storageAccessError(
+        'Failed to delete legacy wallet metadata: $error',
+      );
+    }
+  }
+
+  List<String> _parseActivatedCoins(Object? rawCoins) {
+    if (rawCoins is! String || rawCoins.trim().isEmpty) {
+      return const <String>[];
+    }
+
+    return rawCoins
+        .split(',')
+        .map((coin) => coin.trim())
+        .where((coin) => coin.isNotEmpty)
+        .toList(growable: false);
+  }
+
+  Map<String, dynamic> _parseWalletExtras(Map<String, Object?> row) {
+    final extras = <String, dynamic>{};
+    void addBool(String legacyKey, String outputKey) {
+      final value = row[legacyKey];
+      if (value is int) {
+        extras[outputKey] = value == 1;
+      } else if (value is bool) {
+        extras[outputKey] = value;
+      }
+    }
+
+    addBool('activate_pin_protection', 'activate_pin_protection');
+    addBool('activate_bio_protection', 'activate_bio_protection');
+    addBool('switch_pin_log_out_on_exit', 'switch_pin_log_out_on_exit');
+    addBool('enable_camo', 'enable_camo');
+    addBool('is_camo_active', 'is_camo_active');
+
+    final camoFraction = row['camo_fraction'];
+    if (camoFraction is int) {
+      extras['camo_fraction'] = camoFraction;
+    }
+
+    final camoBalance = row['camo_balance'];
+    if (camoBalance is String && camoBalance.isNotEmpty) {
+      extras['camo_balance'] = camoBalance;
+    }
+
+    final camoSessionStartedAt = row['camo_session_started_at'];
+    if (camoSessionStartedAt is int) {
+      extras['camo_session_started_at'] = camoSessionStartedAt;
+    }
+
+    return extras;
+  }
+}

--- a/packages/komodo_legacy_wallet_migration/lib/src/adapters/legacy_wallet_platform.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/adapters/legacy_wallet_platform.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/foundation.dart';
+
+/// Minimal platform-gating interface for legacy native wallet migration.
+abstract interface class LegacyWalletPlatform {
+  /// Whether the current runtime can access legacy native wallet storage.
+  bool get isSupportedPlatform;
+}
+
+/// Default platform implementation for the production migration service.
+class DefaultLegacyWalletPlatform implements LegacyWalletPlatform {
+  /// Creates the default platform detector.
+  const DefaultLegacyWalletPlatform();
+
+  @override
+  bool get isSupportedPlatform {
+    if (kIsWeb) {
+      return false;
+    }
+
+    return defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS;
+  }
+}

--- a/packages/komodo_legacy_wallet_migration/lib/src/komodo_legacy_wallet_migration.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/komodo_legacy_wallet_migration.dart
@@ -1,0 +1,7 @@
+/// {@template komodo_legacy_wallet_migration}
+/// Legacy wallet migration utilities for Komodo/Gleec SDK apps.
+/// {@endtemplate}
+class KomodoLegacyWalletMigration {
+  /// {@macro komodo_legacy_wallet_migration}
+  const KomodoLegacyWalletMigration();
+}

--- a/packages/komodo_legacy_wallet_migration/lib/src/komodo_legacy_wallet_migration.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/komodo_legacy_wallet_migration.dart
@@ -1,7 +1,359 @@
-/// {@template komodo_legacy_wallet_migration}
+import 'package:komodo_legacy_wallet_migration/src/adapters/legacy_password_verifier.dart';
+import 'package:komodo_legacy_wallet_migration/src/adapters/legacy_secure_storage.dart';
+import 'package:komodo_legacy_wallet_migration/src/adapters/legacy_shared_preferences_store.dart';
+import 'package:komodo_legacy_wallet_migration/src/adapters/legacy_wallet_metadata_store.dart';
+import 'package:komodo_legacy_wallet_migration/src/adapters/legacy_wallet_platform.dart';
+import 'package:komodo_legacy_wallet_migration/src/models/legacy_wallet_cleanup_result.dart';
+import 'package:komodo_legacy_wallet_migration/src/models/legacy_wallet_migration_exception.dart';
+import 'package:komodo_legacy_wallet_migration/src/models/legacy_wallet_record.dart';
+import 'package:komodo_legacy_wallet_migration/src/models/legacy_wallet_secrets.dart';
+
 /// Legacy wallet migration utilities for Komodo/Gleec SDK apps.
-/// {@endtemplate}
 class KomodoLegacyWalletMigration {
-  /// {@macro komodo_legacy_wallet_migration}
-  const KomodoLegacyWalletMigration();
+  /// Creates a migration service with injectable storage/platform adapters.
+  KomodoLegacyWalletMigration({
+    LegacyWalletMetadataStore? metadataStore,
+    LegacySecureStorage? secureStorage,
+    LegacySharedPreferencesStore? sharedPreferencesStore,
+    LegacyPasswordVerifier? passwordVerifier,
+    LegacyWalletPlatform? platform,
+  }) : _metadataStore = metadataStore ?? SqfliteLegacyWalletMetadataStore(),
+       _secureStorage = secureStorage ?? FlutterLegacySecureStorage(),
+       _sharedPreferencesStore =
+           sharedPreferencesStore ?? FlutterLegacySharedPreferencesStore(),
+       _passwordVerifier =
+           passwordVerifier ?? const Argon2LegacyPasswordVerifier(),
+       _platform = platform ?? const DefaultLegacyWalletPlatform();
+
+  final LegacyWalletMetadataStore _metadataStore;
+  final LegacySecureStorage _secureStorage;
+  final LegacySharedPreferencesStore _sharedPreferencesStore;
+  final LegacyPasswordVerifier _passwordVerifier;
+  final LegacyWalletPlatform _platform;
+
+  static const String _seedPrefix = 'KeyEncryption.SEED';
+  static const String _pinPrefix = 'KeyEncryption.PIN';
+  static const String _camoPinPrefix = 'KeyEncryption.CAMOPIN';
+  static const String _passwordPrefix = 'password';
+  static const String _genericPinKey = 'pin';
+  static const String _genericCamoPinKey = 'camoPin';
+  static const String _genericPassphraseKey = 'passphrase';
+  static const String _zhtlcSyncTypeKey = 'zhtlcSyncType';
+  static const String _zhtlcSyncStartDateKey = 'zhtlcSyncStartDate';
+  static const String _zCoinActivationRequestedKeyPrefix =
+      'z-coin-activation-requested-';
+  static const String _disallowScreenshotKey = 'disallowScreenshot';
+
+  /// Whether the current runtime can access legacy native wallet storage.
+  bool get isSupportedPlatform => _platform.isSupportedPlatform;
+
+  /// Lists legacy native wallets available for migration on this device.
+  Future<List<LegacyWalletRecord>> listLegacyWallets() async {
+    if (!isSupportedPlatform) {
+      return const <LegacyWalletRecord>[];
+    }
+
+    return _metadataStore.listWallets();
+  }
+
+  /// Reads the plaintext seed and cleanup keys for [wallet].
+  Future<LegacyWalletSecrets> readWalletSecrets({
+    required LegacyWalletRecord wallet,
+    required String password,
+  }) async {
+    try {
+      final wallets = await _listWallets();
+      final sourceWallet = _findWalletById(wallet, wallets);
+      final cleanupKeys = _buildSecureStorageKeys(
+        wallet: sourceWallet,
+        password: password,
+      );
+      final requestedZhtlcCoinIds = await _readRequestedZhtlcCoinIds(
+        sourceWallet.walletId,
+      );
+      final zhtlcTickers = <String>{
+        ...sourceWallet.activatedCoins,
+        ...requestedZhtlcCoinIds,
+      };
+      final walletExtras = await _readWalletExtras(sourceWallet);
+      final seedPhrase = await _secureStorage.read(cleanupKeys.seedKey);
+      if (seedPhrase != null && seedPhrase.isNotEmpty) {
+        return LegacyWalletSecrets(
+          sourceWallet: sourceWallet,
+          seedPhrase: seedPhrase,
+          secureStorageKeysToDelete: <String>[
+            ...cleanupKeys.toDelete,
+            ...zhtlcTickers.map(
+              (ticker) => '${sourceWallet.walletId}_task_id_$ticker',
+            ),
+          ],
+          genericStorageKeysToDelete:
+              _shouldDeleteGenericSessionKeys(
+                sourceWallet: sourceWallet,
+                wallets: wallets,
+              )
+              ? const <String>[
+                  _genericPinKey,
+                  _genericCamoPinKey,
+                  _genericPassphraseKey,
+                ]
+              : const <String>[],
+          sharedPreferencesKeysToDelete: <String>[
+            '$_zCoinActivationRequestedKeyPrefix${sourceWallet.walletId}',
+          ],
+          requestedZhtlcCoinIds: requestedZhtlcCoinIds,
+          legacyZhtlcSyncType:
+              (await _sharedPreferencesStore.read(_zhtlcSyncTypeKey))
+                  as String?,
+          legacyZhtlcSyncStartDate: _parseLegacySyncStartDate(
+            await _sharedPreferencesStore.read(_zhtlcSyncStartDateKey),
+          ),
+          walletExtras: walletExtras,
+        );
+      }
+
+      final hashKey = _passwordHashKey(sourceWallet);
+      final passwordHash = await _secureStorage.read(hashKey);
+      if (passwordHash != null) {
+        final isValid = await _passwordVerifier.verifySeedPassword(
+          password: password,
+          encodedHash: passwordHash,
+        );
+        if (!isValid) {
+          throw const LegacyWalletMigrationException.incorrectPassword();
+        }
+      }
+
+      throw const LegacyWalletMigrationException.incorrectPassword();
+    } on LegacyWalletMigrationException {
+      rethrow;
+    } on Object catch (error) {
+      throw LegacyWalletMigrationException.storageAccessError(
+        'Failed to read legacy wallet secrets: $error',
+      );
+    }
+  }
+
+  /// Deletes legacy database rows and secure-storage keys for [wallet].
+  Future<LegacyWalletCleanupResult> deleteLegacyWalletData({
+    required LegacyWalletRecord wallet,
+    required String password,
+    LegacyWalletSecrets? secrets,
+  }) async {
+    if (!isSupportedPlatform) {
+      return const LegacyWalletCleanupResult.skipped(
+        warningMessage:
+            'Legacy native wallet cleanup skipped on unsupported platform.',
+      );
+    }
+
+    try {
+      final resolvedSecrets =
+          secrets ??
+          await readWalletSecrets(
+            wallet: wallet,
+            password: password,
+          );
+
+      final criticalDeletionResult = await _deleteSecureStorageKeys(
+        resolvedSecrets.secureStorageKeysToDelete,
+      );
+      final genericDeletionResult = await _deleteSecureStorageKeys(
+        resolvedSecrets.genericStorageKeysToDelete,
+      );
+      final sharedPrefsDeletionResult = await _deleteSharedPreferencesKeys(
+        resolvedSecrets.sharedPreferencesKeysToDelete,
+      );
+
+      var metadataDeleted = false;
+      String? warningMessage;
+      final failedCriticalKeys = criticalDeletionResult.failedKeys;
+      if (failedCriticalKeys.isEmpty) {
+        try {
+          await _metadataStore.deleteWalletData(
+            walletId: resolvedSecrets.sourceWallet.walletId,
+          );
+          metadataDeleted = true;
+        } on LegacyWalletMigrationException catch (error) {
+          warningMessage = error.message;
+        }
+      } else {
+        warningMessage =
+            'Legacy secret cleanup incomplete. '
+            'The legacy wallet remains listed so cleanup can be retried.';
+      }
+
+      final deletedKeys = <String>[
+        ...criticalDeletionResult.deletedKeys,
+        ...genericDeletionResult.deletedKeys,
+      ];
+      final failedKeys = <String>[
+        ...criticalDeletionResult.failedKeys,
+        ...genericDeletionResult.failedKeys,
+      ];
+      final failedSharedPreferencesKeys = sharedPrefsDeletionResult.failedKeys;
+
+      if (metadataDeleted &&
+          failedKeys.isEmpty &&
+          failedSharedPreferencesKeys.isEmpty) {
+        return LegacyWalletCleanupResult.complete(
+          metadataDeleted: true,
+          deletedSecureStorageKeys: deletedKeys,
+        );
+      }
+
+      return LegacyWalletCleanupResult.partial(
+        metadataDeleted: metadataDeleted,
+        deletedSecureStorageKeys: deletedKeys,
+        failedSecureStorageKeys: failedKeys,
+        warningMessage:
+            warningMessage ??
+            (failedSharedPreferencesKeys.isNotEmpty
+                ? 'Legacy wallet cleanup incomplete. '
+                      'Some legacy shared-preferences entries '
+                      'could not be deleted.'
+                : 'Legacy wallet cleanup incomplete. '
+                      'Some legacy secure-storage entries '
+                      'could not be deleted.'),
+      );
+    } on LegacyWalletMigrationException {
+      rethrow;
+    } on Object catch (error) {
+      throw LegacyWalletMigrationException.storageAccessError(
+        'Failed to delete legacy wallet data: $error',
+      );
+    }
+  }
+
+  String _passwordHashKey(LegacyWalletRecord wallet) {
+    return '$_passwordPrefix$_seedPrefix${wallet.walletName}${wallet.walletId}';
+  }
+
+  _SecureStorageKeys _buildSecureStorageKeys({
+    required LegacyWalletRecord wallet,
+    required String password,
+  }) {
+    final suffix = '${wallet.walletName}${wallet.walletId}';
+    final seedKey = '$_seedPrefix$password$suffix';
+    return _SecureStorageKeys(
+      seedKey: seedKey,
+      toDelete: <String>[
+        seedKey,
+        _passwordHashKey(wallet),
+        '$_pinPrefix$password$suffix',
+        '$_camoPinPrefix$password$suffix',
+      ],
+    );
+  }
+
+  Future<List<LegacyWalletRecord>> _listWallets() {
+    return _metadataStore.listWallets();
+  }
+
+  LegacyWalletRecord _findWalletById(
+    LegacyWalletRecord wallet,
+    List<LegacyWalletRecord> wallets,
+  ) {
+    for (final candidate in wallets) {
+      if (candidate.walletId == wallet.walletId) {
+        return candidate;
+      }
+    }
+
+    throw LegacyWalletMigrationException.walletNotFound(wallet.walletId);
+  }
+
+  bool _shouldDeleteGenericSessionKeys({
+    required LegacyWalletRecord sourceWallet,
+    required List<LegacyWalletRecord> wallets,
+  }) {
+    return sourceWallet.isCurrentWallet || wallets.length == 1;
+  }
+
+  Future<_KeyDeletionResult> _deleteSecureStorageKeys(List<String> keys) async {
+    final deletedKeys = <String>[];
+    final failedKeys = <String>[];
+
+    for (final key in keys) {
+      try {
+        await _secureStorage.delete(key);
+        deletedKeys.add(key);
+      } on Object {
+        failedKeys.add(key);
+      }
+    }
+
+    return _KeyDeletionResult(
+      deletedKeys: deletedKeys,
+      failedKeys: failedKeys,
+    );
+  }
+
+  Future<_KeyDeletionResult> _deleteSharedPreferencesKeys(
+    List<String> keys,
+  ) async {
+    final deletedKeys = <String>[];
+    final failedKeys = <String>[];
+
+    for (final key in keys) {
+      try {
+        await _sharedPreferencesStore.delete(key);
+        deletedKeys.add(key);
+      } on Object {
+        failedKeys.add(key);
+      }
+    }
+
+    return _KeyDeletionResult(
+      deletedKeys: deletedKeys,
+      failedKeys: failedKeys,
+    );
+  }
+
+  Future<List<String>> _readRequestedZhtlcCoinIds(String walletId) async {
+    final rawValue = await _sharedPreferencesStore.read(
+      '$_zCoinActivationRequestedKeyPrefix$walletId',
+    );
+    if (rawValue is List<Object?>) {
+      return rawValue.whereType<String>().toList(growable: false);
+    }
+    return const <String>[];
+  }
+
+  Future<Map<String, dynamic>> _readWalletExtras(
+    LegacyWalletRecord sourceWallet,
+  ) async {
+    final extras = <String, dynamic>{...sourceWallet.walletExtras};
+    final disallowScreenshot = await _sharedPreferencesStore.read(
+      _disallowScreenshotKey,
+    );
+    if (disallowScreenshot is bool) {
+      extras['disallow_screenshot'] = disallowScreenshot;
+    }
+    return extras;
+  }
+
+  DateTime? _parseLegacySyncStartDate(Object? rawValue) {
+    if (rawValue is String && rawValue.isNotEmpty) {
+      return DateTime.tryParse(rawValue)?.toUtc();
+    }
+    return null;
+  }
+}
+
+class _SecureStorageKeys {
+  const _SecureStorageKeys({required this.seedKey, required this.toDelete});
+
+  final String seedKey;
+  final List<String> toDelete;
+}
+
+class _KeyDeletionResult {
+  const _KeyDeletionResult({
+    required this.deletedKeys,
+    required this.failedKeys,
+  });
+
+  final List<String> deletedKeys;
+  final List<String> failedKeys;
 }

--- a/packages/komodo_legacy_wallet_migration/lib/src/komodo_legacy_wallet_migration.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/komodo_legacy_wallet_migration.dart
@@ -57,10 +57,17 @@ class KomodoLegacyWalletMigration {
   }
 
   /// Reads the plaintext seed and cleanup keys for [wallet].
+  ///
+  /// Throws [LegacyWalletMigrationException.unsupportedPlatform] on runtimes
+  /// that cannot access native legacy storage (web, desktop).
   Future<LegacyWalletSecrets> readWalletSecrets({
     required LegacyWalletRecord wallet,
     required String password,
   }) async {
+    if (!isSupportedPlatform) {
+      throw const LegacyWalletMigrationException.unsupportedPlatform();
+    }
+
     try {
       final wallets = await _listWallets();
       final sourceWallet = _findWalletById(wallet, wallets);

--- a/packages/komodo_legacy_wallet_migration/lib/src/models/legacy_wallet_cleanup_result.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/models/legacy_wallet_cleanup_result.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/foundation.dart';
+
+/// Cleanup status for legacy native wallet deletion.
+enum LegacyWalletCleanupStatus {
+  /// All targeted legacy artifacts were deleted.
+  complete,
+
+  /// Some legacy artifacts could not be deleted.
+  partial,
+
+  /// Cleanup was skipped because the platform is unsupported.
+  skipped,
+}
+
+/// Result of deleting legacy native wallet artifacts.
+@immutable
+class LegacyWalletCleanupResult {
+  /// Creates a cleanup result.
+  const LegacyWalletCleanupResult({
+    required this.status,
+    required this.metadataDeleted,
+    this.deletedSecureStorageKeys = const <String>[],
+    this.failedSecureStorageKeys = const <String>[],
+    this.warningMessage,
+  });
+
+  /// Cleanup completed successfully.
+  const LegacyWalletCleanupResult.complete({
+    required bool metadataDeleted,
+    required List<String> deletedSecureStorageKeys,
+  }) : this(
+         status: LegacyWalletCleanupStatus.complete,
+         metadataDeleted: metadataDeleted,
+         deletedSecureStorageKeys: deletedSecureStorageKeys,
+       );
+
+  /// Cleanup completed only partially.
+  const LegacyWalletCleanupResult.partial({
+    required bool metadataDeleted,
+    required List<String> deletedSecureStorageKeys,
+    required List<String> failedSecureStorageKeys,
+    required String warningMessage,
+  }) : this(
+         status: LegacyWalletCleanupStatus.partial,
+         metadataDeleted: metadataDeleted,
+         deletedSecureStorageKeys: deletedSecureStorageKeys,
+         failedSecureStorageKeys: failedSecureStorageKeys,
+         warningMessage: warningMessage,
+       );
+
+  /// Cleanup was skipped.
+  const LegacyWalletCleanupResult.skipped({String? warningMessage})
+    : this(
+        status: LegacyWalletCleanupStatus.skipped,
+        metadataDeleted: false,
+        warningMessage: warningMessage,
+      );
+
+  /// Structured status for the cleanup operation.
+  final LegacyWalletCleanupStatus status;
+
+  /// Whether legacy database rows were deleted.
+  final bool metadataDeleted;
+
+  /// Secure-storage keys successfully deleted.
+  final List<String> deletedSecureStorageKeys;
+
+  /// Secure-storage keys that failed deletion.
+  final List<String> failedSecureStorageKeys;
+
+  /// Optional warning message for partial or skipped cleanup.
+  final String? warningMessage;
+
+  /// Whether cleanup completed without any warnings or failures.
+  bool get isComplete => status == LegacyWalletCleanupStatus.complete;
+}

--- a/packages/komodo_legacy_wallet_migration/lib/src/models/legacy_wallet_migration_exception.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/models/legacy_wallet_migration_exception.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/foundation.dart';
+
+/// Error types produced by legacy native wallet migration.
+enum LegacyWalletMigrationExceptionType {
+  /// The runtime cannot access the legacy native wallet storage layout.
+  unsupportedPlatform,
+
+  /// The requested legacy wallet could not be found in storage.
+  walletNotFound,
+
+  /// The provided password did not match the legacy wallet secrets.
+  incorrectPassword,
+
+  /// A storage access operation failed.
+  storageAccessError,
+}
+
+/// Exception thrown by the legacy native wallet migration service.
+@immutable
+class LegacyWalletMigrationException implements Exception {
+  /// Creates a legacy wallet migration exception.
+  const LegacyWalletMigrationException(
+    this.message, {
+    required this.type,
+  });
+
+  /// Creates an unsupported-platform error.
+  const LegacyWalletMigrationException.unsupportedPlatform()
+    : this(
+        'Legacy native wallet migration is not supported on this platform.',
+        type: LegacyWalletMigrationExceptionType.unsupportedPlatform,
+      );
+
+  /// Creates a wallet-not-found error for [walletId].
+  const LegacyWalletMigrationException.walletNotFound(String walletId)
+    : this(
+        'Legacy wallet not found: $walletId',
+        type: LegacyWalletMigrationExceptionType.walletNotFound,
+      );
+
+  /// Creates an incorrect-password error.
+  const LegacyWalletMigrationException.incorrectPassword()
+    : this(
+        'Incorrect legacy wallet password.',
+        type: LegacyWalletMigrationExceptionType.incorrectPassword,
+      );
+
+  /// Creates a storage-access error.
+  const LegacyWalletMigrationException.storageAccessError([String? message])
+    : this(
+        message ?? 'Failed to access legacy wallet storage.',
+        type: LegacyWalletMigrationExceptionType.storageAccessError,
+      );
+
+  /// Human-readable error message.
+  final String message;
+
+  /// Structured error type for callers that need specific handling.
+  final LegacyWalletMigrationExceptionType type;
+
+  @override
+  String toString() {
+    return 'LegacyWalletMigrationException('
+        'type: $type, '
+        'message: $message'
+        ')';
+  }
+}

--- a/packages/komodo_legacy_wallet_migration/lib/src/models/legacy_wallet_record.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/models/legacy_wallet_record.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/foundation.dart';
+
+/// Metadata describing a legacy native wallet discovered on device.
+@immutable
+class LegacyWalletRecord {
+  /// Creates a legacy wallet record.
+  const LegacyWalletRecord({
+    required this.walletId,
+    required this.walletName,
+    this.activatedCoins = const <String>[],
+    this.isCurrentWallet = false,
+    this.walletExtras = const <String, dynamic>{},
+  });
+
+  /// Stable legacy wallet identifier from the native wallet database.
+  final String walletId;
+
+  /// Original legacy wallet name used for secure-storage key lookup.
+  final String walletName;
+
+  /// Activated coin IDs stored for this legacy wallet.
+  final List<String> activatedCoins;
+
+  /// Whether this wallet is marked as the current wallet in legacy storage.
+  final bool isCurrentWallet;
+
+  /// Preserved legacy wallet-scoped extras from native DB/shared prefs state.
+  final Map<String, dynamic> walletExtras;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    return other is LegacyWalletRecord &&
+        other.walletId == walletId &&
+        other.walletName == walletName &&
+        listEquals(other.activatedCoins, activatedCoins) &&
+        other.isCurrentWallet == isCurrentWallet &&
+        mapEquals(other.walletExtras, walletExtras);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    walletId,
+    walletName,
+    Object.hashAll(activatedCoins),
+    isCurrentWallet,
+    Object.hashAllUnordered(
+      walletExtras.entries.map((entry) => Object.hash(entry.key, entry.value)),
+    ),
+  );
+
+  @override
+  String toString() {
+    return 'LegacyWalletRecord('
+        'walletId: $walletId, '
+        'walletName: $walletName, '
+        'activatedCoins: $activatedCoins, '
+        'isCurrentWallet: $isCurrentWallet, '
+        'walletExtras: $walletExtras'
+        ')';
+  }
+}

--- a/packages/komodo_legacy_wallet_migration/lib/src/models/legacy_wallet_secrets.dart
+++ b/packages/komodo_legacy_wallet_migration/lib/src/models/legacy_wallet_secrets.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/foundation.dart';
+import 'package:komodo_legacy_wallet_migration/src/models/legacy_wallet_record.dart';
+
+/// Secrets read from a legacy native wallet during migration.
+@immutable
+class LegacyWalletSecrets {
+  /// Creates a legacy wallet secrets payload.
+  const LegacyWalletSecrets({
+    required this.sourceWallet,
+    required this.seedPhrase,
+    required this.secureStorageKeysToDelete,
+    this.genericStorageKeysToDelete = const <String>[],
+    this.sharedPreferencesKeysToDelete = const <String>[],
+    this.requestedZhtlcCoinIds = const <String>[],
+    this.legacyZhtlcSyncType,
+    this.legacyZhtlcSyncStartDate,
+    this.walletExtras = const <String, dynamic>{},
+  });
+
+  /// Legacy wallet resolved from the native metadata store.
+  final LegacyWalletRecord sourceWallet;
+
+  /// Plaintext seed phrase read directly from legacy secure storage.
+  final String seedPhrase;
+
+  /// Per-wallet secure-storage keys that should be deleted after import.
+  final List<String> secureStorageKeysToDelete;
+
+  /// Generic session keys that can be deleted on a best-effort basis.
+  final List<String> genericStorageKeysToDelete;
+
+  /// Shared-preferences keys that can be deleted after import.
+  final List<String> sharedPreferencesKeysToDelete;
+
+  /// Requested but not yet fully activated legacy ZHTLC coin ids.
+  final List<String> requestedZhtlcCoinIds;
+
+  /// Raw legacy ZHTLC sync type stored by the native app.
+  final String? legacyZhtlcSyncType;
+
+  /// Raw legacy ZHTLC sync start date stored by the native app.
+  final DateTime? legacyZhtlcSyncStartDate;
+
+  /// Preserved legacy wallet-scoped extras.
+  final Map<String, dynamic> walletExtras;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    return other is LegacyWalletSecrets &&
+        other.sourceWallet == sourceWallet &&
+        other.seedPhrase == seedPhrase &&
+        listEquals(
+          other.secureStorageKeysToDelete,
+          secureStorageKeysToDelete,
+        ) &&
+        listEquals(
+          other.genericStorageKeysToDelete,
+          genericStorageKeysToDelete,
+        ) &&
+        listEquals(
+          other.sharedPreferencesKeysToDelete,
+          sharedPreferencesKeysToDelete,
+        ) &&
+        listEquals(other.requestedZhtlcCoinIds, requestedZhtlcCoinIds) &&
+        other.legacyZhtlcSyncType == legacyZhtlcSyncType &&
+        other.legacyZhtlcSyncStartDate == legacyZhtlcSyncStartDate &&
+        mapEquals(other.walletExtras, walletExtras);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    sourceWallet,
+    seedPhrase,
+    Object.hashAll(secureStorageKeysToDelete),
+    Object.hashAll(genericStorageKeysToDelete),
+    Object.hashAll(sharedPreferencesKeysToDelete),
+    Object.hashAll(requestedZhtlcCoinIds),
+    legacyZhtlcSyncType,
+    legacyZhtlcSyncStartDate,
+    Object.hashAllUnordered(
+      walletExtras.entries.map((entry) => Object.hash(entry.key, entry.value)),
+    ),
+  );
+
+  @override
+  String toString() {
+    return 'LegacyWalletSecrets('
+        'sourceWallet: $sourceWallet, '
+        'seedPhrase: [redacted], '
+        'secureStorageKeysToDelete: $secureStorageKeysToDelete, '
+        'genericStorageKeysToDelete: $genericStorageKeysToDelete, '
+        'sharedPreferencesKeysToDelete: $sharedPreferencesKeysToDelete, '
+        'requestedZhtlcCoinIds: $requestedZhtlcCoinIds, '
+        'legacyZhtlcSyncType: $legacyZhtlcSyncType, '
+        'legacyZhtlcSyncStartDate: $legacyZhtlcSyncStartDate, '
+        'walletExtras: $walletExtras'
+        ')';
+  }
+}

--- a/packages/komodo_legacy_wallet_migration/pubspec.yaml
+++ b/packages/komodo_legacy_wallet_migration/pubspec.yaml
@@ -12,10 +12,10 @@ resolution: workspace
 
 dependencies:
   crypto: ^3.0.6
-  dargon2_flutter: ^3.1.0
   encrypt: ^5.0.3
   flutter:
     sdk: flutter
+  pointycastle: ^3.7.0
   flutter_secure_storage: ^10.0.0-beta.4
   komodo_defi_types: ^0.4.0
   logging: ^1.3.0

--- a/packages/komodo_legacy_wallet_migration/pubspec.yaml
+++ b/packages/komodo_legacy_wallet_migration/pubspec.yaml
@@ -1,0 +1,32 @@
+name: komodo_legacy_wallet_migration
+description: Legacy wallet migration utilities for Komodo/Gleec SDK apps.
+version: 0.1.0
+publish_to: none
+repository: https://github.com/GLEECBTC/komodo-defi-sdk-flutter
+
+environment:
+  sdk: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"
+
+resolution: workspace
+
+dependencies:
+  crypto: ^3.0.6
+  dargon2_flutter: ^3.1.0
+  encrypt: ^5.0.3
+  flutter:
+    sdk: flutter
+  flutter_secure_storage: ^10.0.0-beta.4
+  komodo_defi_types: ^0.4.0
+  logging: ^1.3.0
+  path: ^1.9.1
+  path_provider: ^2.1.5
+  shared_preferences: ^2.3.2
+  sqflite: ^2.4.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  mocktail: ^1.0.4
+  test: ^1.25.7
+  very_good_analysis: ^9.0.0

--- a/packages/komodo_legacy_wallet_migration/test/src/komodo_legacy_wallet_migration_test.dart
+++ b/packages/komodo_legacy_wallet_migration/test/src/komodo_legacy_wallet_migration_test.dart
@@ -1,0 +1,13 @@
+// Not required for test files
+// ignore_for_file: prefer_const_constructors
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:komodo_legacy_wallet_migration/komodo_legacy_wallet_migration.dart';
+
+void main() {
+  group('KomodoLegacyWalletMigration', () {
+    test('can be instantiated', () {
+      expect(KomodoLegacyWalletMigration(), isNotNull);
+    });
+  });
+}

--- a/packages/komodo_legacy_wallet_migration/test/src/komodo_legacy_wallet_migration_test.dart
+++ b/packages/komodo_legacy_wallet_migration/test/src/komodo_legacy_wallet_migration_test.dart
@@ -1,13 +1,533 @@
-// Not required for test files
-// ignore_for_file: prefer_const_constructors
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:komodo_legacy_wallet_migration/komodo_legacy_wallet_migration.dart';
+import 'package:komodo_legacy_wallet_migration/src/adapters/legacy_password_verifier.dart';
+import 'package:komodo_legacy_wallet_migration/src/adapters/legacy_secure_storage.dart';
+import 'package:komodo_legacy_wallet_migration/src/adapters/legacy_shared_preferences_store.dart';
+import 'package:komodo_legacy_wallet_migration/src/adapters/legacy_wallet_metadata_store.dart';
+import 'package:komodo_legacy_wallet_migration/src/adapters/legacy_wallet_platform.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('KomodoLegacyWalletMigration', () {
-    test('can be instantiated', () {
-      expect(KomodoLegacyWalletMigration(), isNotNull);
+    late _FakeMetadataStore metadataStore;
+    late _FakeSecureStorage secureStorage;
+    late _FakeSharedPreferencesStore sharedPreferencesStore;
+    late _FakePasswordVerifier passwordVerifier;
+    late _FakePlatform platform;
+    late KomodoLegacyWalletMigration migration;
+
+    const storedWallet = LegacyWalletRecord(
+      walletId: 'wallet-1',
+      walletName: 'Legacy Wallet',
+      activatedCoins: <String>['KMD', 'BTC'],
+      isCurrentWallet: true,
+    );
+
+    setUp(() {
+      metadataStore = _FakeMetadataStore(
+        wallets: <LegacyWalletRecord>[storedWallet],
+      );
+      secureStorage = _FakeSecureStorage();
+      sharedPreferencesStore = _FakeSharedPreferencesStore();
+      passwordVerifier = _FakePasswordVerifier(isValid: true);
+      platform = const _FakePlatform(isSupportedPlatform: true);
+      migration = KomodoLegacyWalletMigration(
+        metadataStore: metadataStore,
+        secureStorage: secureStorage,
+        sharedPreferencesStore: sharedPreferencesStore,
+        passwordVerifier: passwordVerifier,
+        platform: platform,
+      );
     });
+
+    test(
+      'listLegacyWallets returns metadata store wallets on supported platforms',
+      () async {
+        final wallets = await migration.listLegacyWallets();
+
+        expect(wallets, <LegacyWalletRecord>[storedWallet]);
+        expect(metadataStore.listWalletsCalls, 1);
+      },
+    );
+
+    test(
+      'listLegacyWallets returns empty list on unsupported platforms',
+      () async {
+        migration = KomodoLegacyWalletMigration(
+          metadataStore: metadataStore,
+          secureStorage: secureStorage,
+          sharedPreferencesStore: sharedPreferencesStore,
+          passwordVerifier: passwordVerifier,
+          platform: const _FakePlatform(isSupportedPlatform: false),
+        );
+
+        final wallets = await migration.listLegacyWallets();
+
+        expect(wallets, isEmpty);
+        expect(metadataStore.listWalletsCalls, 0);
+      },
+    );
+
+    test(
+      'readWalletSecrets prefers direct seed lookup and returns plaintext seed',
+      () async {
+        secureStorage.values.addAll(<String, String>{
+          'passwordKeyEncryption.SEEDLegacy Walletwallet-1': 'hash-value',
+          'KeyEncryption.SEEDsecretLegacy Walletwallet-1': 'word1 word2 word3',
+        });
+
+        final secrets = await migration.readWalletSecrets(
+          wallet: storedWallet,
+          password: 'secret',
+        );
+
+        expect(passwordVerifier.passwordsChecked, isEmpty);
+        expect(passwordVerifier.hashesChecked, isEmpty);
+        expect(
+          secureStorage.readCalls,
+          <String>['KeyEncryption.SEEDsecretLegacy Walletwallet-1'],
+        );
+        expect(secrets.seedPhrase, 'word1 word2 word3');
+        expect(secrets.sourceWallet, storedWallet);
+        expect(
+          secrets.secureStorageKeysToDelete,
+          <String>[
+            'KeyEncryption.SEEDsecretLegacy Walletwallet-1',
+            'passwordKeyEncryption.SEEDLegacy Walletwallet-1',
+            'KeyEncryption.PINsecretLegacy Walletwallet-1',
+            'KeyEncryption.CAMOPINsecretLegacy Walletwallet-1',
+            'wallet-1_task_id_KMD',
+            'wallet-1_task_id_BTC',
+          ],
+        );
+        expect(
+          secrets.genericStorageKeysToDelete,
+          <String>['pin', 'camoPin', 'passphrase'],
+        );
+      },
+    );
+
+    test(
+      'readWalletSecrets returns the seed even if the optional verifier fails',
+      () async {
+        secureStorage.values.addAll(<String, String>{
+          'passwordKeyEncryption.SEEDLegacy Walletwallet-1': 'hash-value',
+          'KeyEncryption.SEEDsecretLegacy Walletwallet-1': 'word1 word2 word3',
+        });
+        passwordVerifier.isValid = false;
+
+        final secrets = await migration.readWalletSecrets(
+          wallet: storedWallet,
+          password: 'secret',
+        );
+
+        expect(secrets.seedPhrase, 'word1 word2 word3');
+        expect(passwordVerifier.passwordsChecked, isEmpty);
+        expect(
+          secureStorage.readCalls,
+          <String>['KeyEncryption.SEEDsecretLegacy Walletwallet-1'],
+        );
+      },
+    );
+
+    test(
+      'readWalletSecrets rejects invalid passwords after the seed key misses',
+      () async {
+        secureStorage
+                .values['passwordKeyEncryption.SEEDLegacy Walletwallet-1'] =
+            'hash-value';
+        passwordVerifier.isValid = false;
+
+        await expectLater(
+          () => migration.readWalletSecrets(
+            wallet: storedWallet,
+            password: 'wrong',
+          ),
+          throwsA(
+            isA<LegacyWalletMigrationException>().having(
+              (error) => error.type,
+              'type',
+              LegacyWalletMigrationExceptionType.incorrectPassword,
+            ),
+          ),
+        );
+
+        expect(
+          secureStorage.readCalls,
+          <String>[
+            'KeyEncryption.SEEDwrongLegacy Walletwallet-1',
+            'passwordKeyEncryption.SEEDLegacy Walletwallet-1',
+          ],
+        );
+      },
+    );
+
+    test(
+      'readWalletSecrets treats missing seed data key as incorrect password',
+      () async {
+        secureStorage
+                .values['passwordKeyEncryption.SEEDLegacy Walletwallet-1'] =
+            'hash-value';
+
+        await expectLater(
+          () => migration.readWalletSecrets(
+            wallet: storedWallet,
+            password: 'wrong',
+          ),
+          throwsA(
+            isA<LegacyWalletMigrationException>().having(
+              (error) => error.type,
+              'type',
+              LegacyWalletMigrationExceptionType.incorrectPassword,
+            ),
+          ),
+        );
+
+        expect(
+          secureStorage.readCalls,
+          <String>[
+            'KeyEncryption.SEEDwrongLegacy Walletwallet-1',
+            'passwordKeyEncryption.SEEDLegacy Walletwallet-1',
+          ],
+        );
+        expect(passwordVerifier.passwordsChecked, <String>['wrong']);
+        expect(passwordVerifier.hashesChecked, <String>['hash-value']);
+      },
+    );
+
+    test(
+      'readWalletSecrets resolves the original wallet name by wallet id',
+      () async {
+        secureStorage
+                .values['passwordKeyEncryption.SEEDLegacy Walletwallet-1'] =
+            'hash-value';
+        secureStorage.values['KeyEncryption.SEEDsecretLegacy Walletwallet-1'] =
+            'seed words';
+
+        final secrets = await migration.readWalletSecrets(
+          wallet: const LegacyWalletRecord(
+            walletId: 'wallet-1',
+            walletName: 'Sanitized_Name',
+          ),
+          password: 'secret',
+        );
+
+        expect(secrets.seedPhrase, 'seed words');
+        expect(
+          secureStorage.readCalls.last,
+          'KeyEncryption.SEEDsecretLegacy Walletwallet-1',
+        );
+      },
+    );
+
+    test(
+      'readWalletSecrets includes legacy special-case state and cleanup keys',
+      () async {
+        const zhtlcWallet = LegacyWalletRecord(
+          walletId: 'wallet-z',
+          walletName: 'Z Wallet',
+          activatedCoins: <String>['ARRR'],
+          isCurrentWallet: true,
+          walletExtras: <String, dynamic>{
+            'activate_pin_protection': true,
+            'enable_camo': true,
+          },
+        );
+        metadataStore = _FakeMetadataStore(
+          wallets: const <LegacyWalletRecord>[zhtlcWallet],
+        );
+        migration = KomodoLegacyWalletMigration(
+          metadataStore: metadataStore,
+          secureStorage: secureStorage,
+          sharedPreferencesStore: sharedPreferencesStore,
+          passwordVerifier: passwordVerifier,
+          platform: platform,
+        );
+        secureStorage.values.addAll(<String, String>{
+          'passwordKeyEncryption.SEEDZ Walletwallet-z': 'hash-value',
+          'KeyEncryption.SEEDsecretZ Walletwallet-z': 'seed words',
+        });
+        sharedPreferencesStore.values.addAll(<String, Object?>{
+          'z-coin-activation-requested-wallet-z': <String>['ARRR'],
+          'zhtlcSyncType': 'specifiedDate',
+          'zhtlcSyncStartDate': '2025-01-02T03:04:05.000Z',
+          'disallowScreenshot': true,
+        });
+
+        final secrets = await migration.readWalletSecrets(
+          wallet: zhtlcWallet,
+          password: 'secret',
+        );
+
+        expect(secrets.requestedZhtlcCoinIds, <String>['ARRR']);
+        expect(secrets.legacyZhtlcSyncType, 'specifiedDate');
+        expect(
+          secrets.legacyZhtlcSyncStartDate,
+          DateTime.parse('2025-01-02T03:04:05.000Z').toUtc(),
+        );
+        expect(
+          secrets.walletExtras,
+          <String, dynamic>{
+            'activate_pin_protection': true,
+            'enable_camo': true,
+            'disallow_screenshot': true,
+          },
+        );
+        expect(
+          secrets.sharedPreferencesKeysToDelete,
+          <String>['z-coin-activation-requested-wallet-z'],
+        );
+        expect(
+          secrets.secureStorageKeysToDelete,
+          contains('wallet-z_task_id_ARRR'),
+        );
+      },
+    );
+
+    test(
+      'deleteLegacyWalletData removes DB rows and secure storage keys',
+      () async {
+        secureStorage.values.addAll(<String, String>{
+          'passwordKeyEncryption.SEEDLegacy Walletwallet-1': 'hash-value',
+          'KeyEncryption.SEEDsecretLegacy Walletwallet-1': 'seed words',
+        });
+
+        final result = await migration.deleteLegacyWalletData(
+          wallet: storedWallet,
+          password: 'secret',
+        );
+
+        expect(result.isComplete, isTrue);
+        expect(metadataStore.deletedWalletIds, <String>['wallet-1']);
+        expect(
+          secureStorage.deleteCalls,
+          <String>[
+            'KeyEncryption.SEEDsecretLegacy Walletwallet-1',
+            'passwordKeyEncryption.SEEDLegacy Walletwallet-1',
+            'KeyEncryption.PINsecretLegacy Walletwallet-1',
+            'KeyEncryption.CAMOPINsecretLegacy Walletwallet-1',
+            'wallet-1_task_id_KMD',
+            'wallet-1_task_id_BTC',
+            'pin',
+            'camoPin',
+            'passphrase',
+          ],
+        );
+      },
+    );
+
+    test(
+      'deleteLegacyWalletData uses provided secrets without re-reading storage',
+      () async {
+        const secrets = LegacyWalletSecrets(
+          sourceWallet: storedWallet,
+          seedPhrase: 'seed words',
+          secureStorageKeysToDelete: <String>[
+            'KeyEncryption.SEEDsecretLegacy Walletwallet-1',
+          ],
+        );
+
+        final result = await migration.deleteLegacyWalletData(
+          wallet: storedWallet,
+          password: 'secret',
+          secrets: secrets,
+        );
+
+        expect(result.isComplete, isTrue);
+        expect(secureStorage.readCalls, isEmpty);
+        expect(metadataStore.deletedWalletIds, <String>['wallet-1']);
+      },
+    );
+
+    test(
+      'deleteLegacyWalletData returns partial and keeps metadata when a '
+      'critical key fails deletion',
+      () async {
+        secureStorage.values.addAll(<String, String>{
+          'passwordKeyEncryption.SEEDLegacy Walletwallet-1': 'hash-value',
+          'KeyEncryption.SEEDsecretLegacy Walletwallet-1': 'seed words',
+        });
+        secureStorage.keysThatFailDeletion.add(
+          'KeyEncryption.SEEDsecretLegacy Walletwallet-1',
+        );
+
+        final result = await migration.deleteLegacyWalletData(
+          wallet: storedWallet,
+          password: 'secret',
+        );
+
+        expect(result.status, LegacyWalletCleanupStatus.partial);
+        expect(result.metadataDeleted, isFalse);
+        expect(metadataStore.deletedWalletIds, isEmpty);
+        expect(
+          result.failedSecureStorageKeys,
+          <String>['KeyEncryption.SEEDsecretLegacy Walletwallet-1'],
+        );
+      },
+    );
+
+    test(
+      'deleteLegacyWalletData returns partial when generic key deletion fails '
+      'after metadata cleanup',
+      () async {
+        secureStorage.values.addAll(<String, String>{
+          'passwordKeyEncryption.SEEDLegacy Walletwallet-1': 'hash-value',
+          'KeyEncryption.SEEDsecretLegacy Walletwallet-1': 'seed words',
+        });
+        secureStorage.keysThatFailDeletion.add('passphrase');
+
+        final result = await migration.deleteLegacyWalletData(
+          wallet: storedWallet,
+          password: 'secret',
+        );
+
+        expect(result.status, LegacyWalletCleanupStatus.partial);
+        expect(result.metadataDeleted, isTrue);
+        expect(metadataStore.deletedWalletIds, <String>['wallet-1']);
+        expect(result.failedSecureStorageKeys, <String>['passphrase']);
+      },
+    );
+
+    test(
+      'deleteLegacyWalletData returns partial when shared-preferences cleanup '
+      'fails after metadata cleanup',
+      () async {
+        secureStorage.values.addAll(<String, String>{
+          'passwordKeyEncryption.SEEDLegacy Walletwallet-1': 'hash-value',
+          'KeyEncryption.SEEDsecretLegacy Walletwallet-1': 'seed words',
+        });
+        sharedPreferencesStore.values['z-coin-activation-requested-wallet-1'] =
+            <String>['ARRR'];
+        sharedPreferencesStore.keysThatFailDeletion.add(
+          'z-coin-activation-requested-wallet-1',
+        );
+
+        final result = await migration.deleteLegacyWalletData(
+          wallet: storedWallet,
+          password: 'secret',
+        );
+
+        expect(result.status, LegacyWalletCleanupStatus.partial);
+        expect(result.metadataDeleted, isTrue);
+        expect(result.warningMessage, contains('shared-preferences'));
+      },
+    );
+
+    test(
+      'readWalletSecrets omits generic session keys for a non-current wallet '
+      'when others remain',
+      () async {
+        const otherWallet = LegacyWalletRecord(
+          walletId: 'wallet-2',
+          walletName: 'Other Wallet',
+          activatedCoins: <String>['ETH'],
+        );
+        metadataStore = _FakeMetadataStore(
+          wallets: const <LegacyWalletRecord>[storedWallet, otherWallet],
+        );
+        migration = KomodoLegacyWalletMigration(
+          metadataStore: metadataStore,
+          secureStorage: secureStorage,
+          sharedPreferencesStore: sharedPreferencesStore,
+          passwordVerifier: passwordVerifier,
+          platform: platform,
+        );
+        secureStorage.values.addAll(<String, String>{
+          'passwordKeyEncryption.SEEDOther Walletwallet-2': 'hash-value',
+          'KeyEncryption.SEEDsecretOther Walletwallet-2': 'seed words',
+        });
+
+        final secrets = await migration.readWalletSecrets(
+          wallet: otherWallet,
+          password: 'secret',
+        );
+
+        expect(secrets.genericStorageKeysToDelete, isEmpty);
+      },
+    );
   });
+}
+
+class _FakeMetadataStore implements LegacyWalletMetadataStore {
+  _FakeMetadataStore({required this.wallets});
+
+  final List<LegacyWalletRecord> wallets;
+  int listWalletsCalls = 0;
+  final List<String> deletedWalletIds = <String>[];
+
+  @override
+  Future<void> deleteWalletData({required String walletId}) async {
+    deletedWalletIds.add(walletId);
+  }
+
+  @override
+  Future<List<LegacyWalletRecord>> listWallets() async {
+    listWalletsCalls += 1;
+    return wallets;
+  }
+}
+
+class _FakeSecureStorage implements LegacySecureStorage {
+  final Map<String, String> values = <String, String>{};
+  final List<String> readCalls = <String>[];
+  final List<String> deleteCalls = <String>[];
+  final Set<String> keysThatFailDeletion = <String>{};
+
+  @override
+  Future<void> delete(String key) async {
+    if (keysThatFailDeletion.contains(key)) {
+      throw StateError('delete failed for $key');
+    }
+    deleteCalls.add(key);
+  }
+
+  @override
+  Future<String?> read(String key) async {
+    readCalls.add(key);
+    return values[key];
+  }
+}
+
+class _FakePasswordVerifier implements LegacyPasswordVerifier {
+  _FakePasswordVerifier({required this.isValid});
+
+  bool isValid;
+  final List<String> passwordsChecked = <String>[];
+  final List<String> hashesChecked = <String>[];
+
+  @override
+  Future<bool> verifySeedPassword({
+    required String password,
+    required String encodedHash,
+  }) async {
+    passwordsChecked.add(password);
+    hashesChecked.add(encodedHash);
+    return isValid;
+  }
+}
+
+class _FakePlatform implements LegacyWalletPlatform {
+  const _FakePlatform({required this.isSupportedPlatform});
+
+  @override
+  final bool isSupportedPlatform;
+}
+
+class _FakeSharedPreferencesStore implements LegacySharedPreferencesStore {
+  final Map<String, Object?> values = <String, Object?>{};
+  final Set<String> keysThatFailDeletion = <String>{};
+  final List<String> deleteCalls = <String>[];
+
+  @override
+  Future<void> delete(String key) async {
+    if (keysThatFailDeletion.contains(key)) {
+      throw StateError('delete failed for $key');
+    }
+    deleteCalls.add(key);
+    values.remove(key);
+  }
+
+  @override
+  Future<Object?> read(String key) async => values[key];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ workspace:
   - packages/dragon_charts_flutter
   - packages/dragon_charts_flutter/example
   - packages/komodo_wallet_cli
+  - packages/komodo_legacy_wallet_migration
 
   # TODO: Change products and playground to reference pub.dev hosted packages and remove from here.
   - products/dex_dungeon


### PR DESCRIPTION
## Status

**READY**

## Description

Adds end-to-end support for migrating legacy native-app wallets into KDF-managed wallets.

### New package: `komodo_legacy_wallet_migration`
- Platform-abstracted discovery of legacy wallets (secure storage, shared preferences, metadata files)
- Argon2-based legacy password verification using pure-Dart `pointycastle` (WASM-compatible, replaces `dargon2_flutter`)
- Models for `LegacyWalletRecord`, `LegacyWalletSecrets`, `LegacyWalletCleanupResult`, and migration exceptions
- Orchestrator that prepares migrations, extracts seed phrases, and cleans up legacy data on completion
- Comprehensive unit tests (533+ lines)

### `komodo_defi_sdk`
- New `ZhtlcRecurringSyncPolicy` type and persistence — separates persisted recurring sync preferences from one-shot sync overrides so reactivations use the correct policy without accidental rewinds
- `ActivationConfigService` gains recurring-policy CRUD, one-shot consume/take semantics, and migration-aware config promotion
- ZHTLC activation strategy now applies one-shot sync params once and omits `sync_params` on subsequent activations
- New unit tests for `ActivationConfigService` and `ZhtlcActivationStrategy` one-shot behavior

### `komodo_defi_framework`
- Harden KDF start/stop readiness checks: native-status polling (no HTTP during shutdown), bounded version-probe timeouts, and `resetHttpClient()` after stop to drop stale keep-alive sockets
- `isRunning()` gains `allowVersionFallback` parameter to avoid HTTP probes during shutdown verification

### `komodo_defi_local_auth`
- Auth registration now returns the `KdfUser` directly instead of requiring a post-register read
- `_waitUntilKdfRpcReady()` replaces `_waitUntilKdfRpcIsUp()` with stricter two-phase readiness (status + version probe) and configurable timeouts
- New `_runStartupSensitiveRpc()` retry wrapper that resets the HTTP client and re-waits for RPC readiness on transport failures
- Detailed per-phase stopwatch logging throughout register, restart, and authentication flows

### `komodo_defi_types`
- `AuthExceptionType.legacyWalletAlreadyMigrated` variant and convenience constructor

### `komodo_defi_rpc_methods`
- Updated `sync_params` doc comments to clarify client-optional / backend-resume semantics

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor