### PR TITLE
Revert analysis options changes

### DIFF
--- a/packages/dragon_charts_flutter/analysis_options.yaml
+++ b/packages/dragon_charts_flutter/analysis_options.yaml
@@ -1,19 +1,6 @@
 include: package:very_good_analysis/analysis_options.yaml
-analyzer:
-  errors:
-    deprecated_member_use: ignore
-    document_ignores: ignore
-    unused_element: ignore
 linter:
   rules:
-    cascade_invocations: false
-    document_ignores: false
-    flutter_style_todos: false
-    library_private_types_in_public_api: false
-    lines_longer_than_80_chars: false
-    noop_primitive_operations: false
-    prefer_asserts_with_message: false
     public_member_api_docs: false
-    use_late_for_private_fields_and_variables: false
     prefer_int_literals: false
     omit_local_variable_types: false

--- a/packages/komodo_ui/analysis_options.yaml
+++ b/packages/komodo_ui/analysis_options.yaml
@@ -1,25 +1,7 @@
 include: package:very_good_analysis/analysis_options.6.0.0.yaml
 analyzer:
   errors:
-    avoid_redundant_argument_values: ignore
-    cascade_invocations: ignore
-    comment_references: ignore
-    deprecated_member_use: ignore
-    flutter_style_todos: ignore
-    inference_failure_on_instance_creation: ignore
-    lines_longer_than_80_chars: ignore
-    omit_local_variable_types: ignore
-    public_member_api_docs: ignore
-    unnecessary_non_null_assertion: ignore
-    unused_element: ignore
     use_if_null_to_convert_nulls_to_bools: ignore
 linter:
   rules:
-    avoid_positional_boolean_parameters: false
-    avoid_redundant_argument_values: false
-    cascade_invocations: false
-    flutter_style_todos: false
-    lines_longer_than_80_chars: false
-    omit_local_variable_types: false
-    public_member_api_docs: false
-    eol_at_end_of_file: true
+    - eol_at_end_of_file


### PR DESCRIPTION
## Summary

- Revert the `analysis_options.yaml` changes introduced in the latest `dev` commit.
- Scope is limited to `packages/dragon_charts_flutter/analysis_options.yaml` and `packages/komodo_ui/analysis_options.yaml`.

## Validation

- Not run locally; change only restores the prior analysis option file contents.