### PR TITLE
fix(android): align native LOAD segments to 16 KB pages

### DIFF
--- a/packages/komodo_defi_framework/src/CMakeLists.txt
+++ b/packages/komodo_defi_framework/src/CMakeLists.txt
@@ -34,4 +34,12 @@ if(ANDROID)
     "${KDFLIB_PATH}"
     "-Wl,--no-whole-archive"
   )
+
+  # Align LOAD segments to 16 KB so the library loads on Android 15+ devices
+  # that use 16 KB memory pages (required by Google Play for apps targeting
+  # Android 15+). Without this the prebuilt libkdf.a links a 4 KB-aligned .so
+  # and Play reports the app as incompatible ("made for an older version").
+  target_link_options(komodo_defi_framework PRIVATE
+    "-Wl,-z,max-page-size=16384"
+  )
 endif()


### PR DESCRIPTION
Google Play requires apps targeting Android 15+ to support devices that use 16 KB memory pages. The prebuilt libkdf.a otherwise links a 4 KB page-aligned .so, which fails to load on 16 KB-page devices and causes Play to flag the app as incompatible ("made for an older version of Android").

Pass -Wl,-z,max-page-size=16384 when linking komodo_defi_framework on Android so the resulting shared library is 16 KB-aligned and loads on both 4 KB and 16 KB page-size devices.

Ref: https://developer.android.com/guide/practices/page-sizes?hl=en#build