### PR TITLE
chore(build): update KDF and coins config

### DIFF
--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -25,10 +25,10 @@
         "path": "ios"
       },
       "macos": {
-        "matching_pattern": "^(?:kdf-macos-universal2-[a-f0-9]{7,40}|kdf_[a-f0-9]{7,40}-mac-universal|libkdf-macos-universal2-[a-f0-9]{7,40})\\.zip$",
-        "matching_preference": ["universal2", "mac-arm64"],
+        "matching_pattern": "^(?:kdf-macos-universal2-[a-f0-9]{7,40}|kdf_[a-f0-9]{7,40}-mac-universal)\\.zip$",
+        "matching_preference": ["kdf-macos-universal2-", "mac-universal"],
         "valid_zip_sha256_checksums": [
-          "14a1473d46706fdfbd04d18939994b686016a126e4dc2cb8937d00f5645b8773"
+          "d2896495fe813729d5e5612027cd0c8bf18f771d9c49552ee3f545df9bae868b"
         ],
         "path": "macos/bin"
       },
@@ -65,7 +65,7 @@
   "coins": {
     "fetch_at_build_enabled": true,
     "update_commit_on_build": true,
-    "bundled_coins_repo_commit": "883f1863cc71ad5f7a04878e4b7073d5f9f98dcf",
+    "bundled_coins_repo_commit": "acc4c32b379fb8b9ea387a269d33b32bcf084079",
     "coins_repo_api_url": "https://api.github.com/repos/GLEECBTC/coins",
     "coins_repo_content_url": "https://raw.githubusercontent.com/GLEECBTC/coins",
     "coins_repo_branch": "master",


### PR DESCRIPTION
## Summary

- Pin macOS KDF artifact matching to universal KDF binary archives instead of the static-library archive.
- Update the macOS checksum to `kdf_d56a7bc-mac-universal.zip`.
- Roll the bundled coins repo commit to `acc4c32b379fb8b9ea387a269d33b32bcf084079`.

## Validation

- Verified `packages/komodo_defi_framework/app_build/build_config.json` parses as JSON.
- Ran the KDF config roll tool for macOS and confirmed it selects `https://devbuilds.gleec.com/main/kdf_d56a7bc-mac-universal.zip` with checksum `d2896495fe813729d5e5612027cd0c8bf18f771d9c49552ee3f545df9bae868b`.
- Ran the SDK build transformer twice; second run reported all artifacts up to date and copied platform assets successfully.
- Built the wallet app with `flutter build macos --no-pub --release` with code signing disabled; build succeeded.

## Notes

`flutter analyze` was run from the wallet repo and still fails on existing analyzer debt unrelated to this config change.